### PR TITLE
Support for map initialization

### DIFF
--- a/.github/workflows/PRCheck.yml
+++ b/.github/workflows/PRCheck.yml
@@ -39,9 +39,9 @@ jobs:
       
       - name: Setup Ballerina pack
         run: |
-          curl -L  https://maven.pkg.github.com/ballerina-platform/ballerina-lang/org/ballerinalang/jballerina-tools/2.0.0-Preview2-nballerina-r1/jballerina-tools-2.0.0-Preview2-nballerina-r1.zip -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" -o jballerina-tools-2.0.0-Preview2-nballerina-r1.zip
-          unzip -q jballerina-tools-2.0.0-Preview2-nballerina-r1.zip
-          cd jballerina-tools-2.0.0-Preview2-nballerina-r1/bin
+          curl -L  https://maven.pkg.github.com/ballerina-platform/ballerina-lang/org/ballerinalang/jballerina-tools/2.0.0-Preview2-nballerina-r2/jballerina-tools-2.0.0-Preview2-nballerina-r2.zip -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" -o jballerina-tools-2.0.0-Preview2-nballerina-r2.zip
+          unzip -q jballerina-tools-2.0.0-Preview2-nballerina-r2.zip
+          cd jballerina-tools-2.0.0-Preview2-nballerina-r2/bin
           echo $(pwd) >> $GITHUB_PATH
         working-directory: ./build
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This will build:
 ### Run tests
 1. Install Java 8 runtime (e.g. openjdk-8-jre on ubuntu)
 2. Create `JAVA_HOME` environment variable and point it to the Java install dir
-3. Get this specific Ballerina version : [jballerina-tools-2.0.0-Preview2-nballerina-r2.zip](https://github.com/ballerina-platform/ballerina-lang/packages/413010)
+3. Get this specific Ballerina version : [jballerina-tools-2.0.0-Preview2-nballerina-r2.zip](https://github.com/ballerina-platform/ballerina-lang/packages/413010?version=2.0.0-Preview2-nballerina-r2)
 4. Extract Ballerina pack and add the `bin` folder with the `ballerina` executable to your `PATH` system variable 
 5. Run:
 
@@ -60,7 +60,7 @@ This will build:
 ### Run tests
 1. Install Java 8 runtime (e.g. JRE 8 package for MacOS)
 2. Create `JAVA_HOME` environment variable and point it to the Java install dir
-3. Get this specific Ballerina version : [link](https://drive.google.com/file/d/1a1TlJdw-rTtCLOFrrvJe4nr1FkGzwpKH/view?usp=sharing)
+3. Get this specific Ballerina version : [jballerina-tools-2.0.0-Preview2-nballerina-r2.zip](https://github.com/ballerina-platform/ballerina-lang/packages/413010?version=2.0.0-Preview2-nballerina-r2)
 4. Extract Ballerina pack and add the `bin` folder with the `ballerina` executable to your `PATH` system variable 
 5. Navigate to nBallerina `build/` folder and run tests
 
@@ -130,7 +130,7 @@ Clone the nballerina source and run below commands.
         pip3 Install lit filecheck
 
 3. Install java and set up JAVA_HOME in your PATH system variable
-4. Get this specific Ballerina version : [link](https://drive.google.com/file/d/1a1TlJdw-rTtCLOFrrvJe4nr1FkGzwpKH/view?usp=sharing)
+4. Get this specific Ballerina version : [jballerina-tools-2.0.0-Preview2-nballerina-r2.zip](https://github.com/ballerina-platform/ballerina-lang/packages/413010?version=2.0.0-Preview2-nballerina-r2)
 5. Extract Ballerina pack and add the bin folder with the ballerina executable to your PATH system variable
 4. Run tests
 

--- a/compiler/BIRReader.cpp
+++ b/compiler/BIRReader.cpp
@@ -265,6 +265,19 @@ Operand BIRReader::readOperand() {
     return Operand(constantPool->getStringCp(varDclNameCpIndex), (VarKind)kind);
 }
 
+// Read Mapping Constructor Key Value body
+MappingConstructorKeyValue BIRReader::readMappingConstructorKeyValue() {
+
+    auto kind = readU1();
+    if ((MappingConstructorBodyKind)kind != Key_Value_Kind) {
+        llvm_unreachable("Unsupported mapping_constructor_body_kind");
+    }
+    auto key = readOperand();
+    auto value = readOperand();
+
+    return MappingConstructorKeyValue(key, value);
+}
+
 // Read TYPEDESC Insn
 std::unique_ptr<TypeDescInsn> ReadTypeDescInsn::readNonTerminatorInsn(std::shared_ptr<BasicBlock> currentBB) {
     auto lhsOp = readerRef.readOperand();
@@ -276,7 +289,14 @@ std::unique_ptr<TypeDescInsn> ReadTypeDescInsn::readNonTerminatorInsn(std::share
 std::unique_ptr<StructureInsn> ReadStructureInsn::readNonTerminatorInsn(std::shared_ptr<BasicBlock> currentBB) {
     auto rhsOp = readerRef.readOperand();
     [[maybe_unused]] auto lhsOp = readerRef.readOperand();
-    return std::make_unique<StructureInsn>(std::move(lhsOp), currentBB);
+
+    auto initValuesCount = readerRef.readS4be();
+    std::vector<MappingConstructorKeyValue> initValues;
+    initValues.reserve(initValuesCount);
+    for (size_t i = 0; i < initValuesCount; i++) {
+        initValues.push_back(readerRef.readMappingConstructorKeyValue());
+    }
+    return std::make_unique<StructureInsn>(std::move(lhsOp), currentBB, std::move(initValues));
 }
 
 // Read CONST_LOAD Insn
@@ -411,6 +431,12 @@ std::unique_ptr<ArrayInsn> ReadArrayInsn::readNonTerminatorInsn(std::shared_ptr<
     Type typeDecl = readerRef.constantPool->getTypeCp(typeCpIndex, false);
     auto lhsOp = readerRef.readOperand();
     auto sizeOperand = readerRef.readOperand();
+
+    // TODO handle Array init values
+    auto init_values_count = readerRef.readS4be();
+    for (size_t i = 0; i < init_values_count; i++) {
+        [[maybe_unused]] auto init_value = readerRef.readOperand();
+    }
     return std::make_unique<ArrayInsn>(lhsOp, currentBB, sizeOperand);
 }
 

--- a/compiler/BIRReader.cpp
+++ b/compiler/BIRReader.cpp
@@ -266,16 +266,16 @@ Operand BIRReader::readOperand() {
 }
 
 // Read Mapping Constructor Key Value body
-MappingConstructorKeyValue BIRReader::readMappingConstructorKeyValue() {
+MapConstrctKeyValue BIRReader::readMappingConstructorKeyValue() {
 
     auto kind = readU1();
-    if ((MappingConstructorBodyKind)kind != Key_Value_Kind) {
+    if ((MapConstrctBodyKind)kind != Key_Value_Kind) {
         llvm_unreachable("Unsupported mapping_constructor_body_kind");
     }
     auto key = readOperand();
     auto value = readOperand();
 
-    return MappingConstructorKeyValue(key, value);
+    return MapConstrctKeyValue(key, value);
 }
 
 // Read TYPEDESC Insn
@@ -291,7 +291,12 @@ std::unique_ptr<StructureInsn> ReadStructureInsn::readNonTerminatorInsn(std::sha
     [[maybe_unused]] auto lhsOp = readerRef.readOperand();
 
     auto initValuesCount = readerRef.readS4be();
-    std::vector<MappingConstructorKeyValue> initValues;
+
+    if (initValuesCount == 0) {
+        return std::make_unique<StructureInsn>(std::move(lhsOp), currentBB);
+    }
+
+    std::vector<MapConstrctKeyValue> initValues;
     initValues.reserve(initValuesCount);
     for (size_t i = 0; i < initValuesCount; i++) {
         initValues.push_back(readerRef.readMappingConstructorKeyValue());

--- a/compiler/BIRReader.cpp
+++ b/compiler/BIRReader.cpp
@@ -170,18 +170,18 @@ Type ConstantPoolSet::getTypeCp(uint32_t index, bool voidToInt) {
 
     // Handle voidToInt flag
     if (type == TYPE_TAG_NIL && voidToInt)
-        return Type(TYPE_TAG_INT, name, shapeCp->getTypeFlag());
+        return Type(TYPE_TAG_INT, name);
 
     // Handle Map type
     if (type == TYPE_TAG_MAP) {
         ConstantPoolEntry *shapeEntry = getEntry(shapeCp->getConstraintTypeCpIndex());
         assert(shapeEntry->getTag() == ConstantPoolEntry::tagEnum::TAG_ENUM_CP_ENTRY_SHAPE);
         ShapeCpInfo *typeShapeCp = static_cast<ShapeCpInfo *>(shapeEntry);
-        return Type(type, name, shapeCp->getTypeFlag(), typeShapeCp->getTypeTag());
+        return Type(type, name, typeShapeCp->getTypeTag());
     }
 
     // Default return
-    return Type(type, name, shapeCp->getTypeFlag());
+    return Type(type, name);
 }
 
 // Get the Type tag from the constant pool based on the index passed

--- a/compiler/BIRReader.cpp
+++ b/compiler/BIRReader.cpp
@@ -266,17 +266,17 @@ Operand BIRReader::readOperand() {
 }
 
 // Read Mapping Constructor Key Value body
-std::unique_ptr<MapConstruct> BIRReader::readMapConstructor() {
+MapConstruct BIRReader::readMapConstructor() {
 
     auto kind = readU1();
     if ((MapConstrctBodyKind)kind == Spread_Field_Kind) {
         auto expr = readOperand();
-        return std::make_unique<MapConstructSpreadField>(expr);
+        return MapConstruct(SpreadField(expr));
     }
     // For Key_Value_Kind
     auto key = readOperand();
     auto value = readOperand();
-    return std::make_unique<MapConstructKeyValue>(key, value);
+    return MapConstruct(KeyValue(key, value));
 }
 
 // Read TYPEDESC Insn
@@ -297,7 +297,7 @@ std::unique_ptr<StructureInsn> ReadStructureInsn::readNonTerminatorInsn(std::sha
         return std::make_unique<StructureInsn>(std::move(lhsOp), currentBB);
     }
 
-    std::vector<std::unique_ptr<MapConstruct>> initValues;
+    std::vector<MapConstruct> initValues;
     initValues.reserve(initValuesCount);
     for (size_t i = 0; i < initValuesCount; i++) {
         initValues.push_back(readerRef.readMapConstructor());

--- a/compiler/BIRReader.cpp
+++ b/compiler/BIRReader.cpp
@@ -271,12 +271,12 @@ MapConstruct BIRReader::readMapConstructor() {
     auto kind = readU1();
     if ((MapConstrctBodyKind)kind == Spread_Field_Kind) {
         auto expr = readOperand();
-        return MapConstruct(SpreadField(expr));
+        return MapConstruct(MapConstruct::SpreadField(expr));
     }
     // For Key_Value_Kind
     auto key = readOperand();
     auto value = readOperand();
-    return MapConstruct(KeyValue(key, value));
+    return MapConstruct(MapConstruct::KeyValue(key, value));
 }
 
 // Read TYPEDESC Insn

--- a/compiler/BIRReader.h
+++ b/compiler/BIRReader.h
@@ -62,7 +62,7 @@ class BIRReader {
     nballerina::Variable readGlobalVar();
     nballerina::Operand readOperand();
     nballerina::Variable readLocalVar();
-    nballerina::MappingConstructorKeyValue readMappingConstructorKeyValue();
+    nballerina::MapConstrctKeyValue readMappingConstructorKeyValue();
     nballerina::TypeDescInsn *readTypeDescInsn();
     nballerina::StructureInsn *readStructureInsn();
     void readInsn(std::shared_ptr<nballerina::BasicBlock> basicBlock);

--- a/compiler/BIRReader.h
+++ b/compiler/BIRReader.h
@@ -62,6 +62,7 @@ class BIRReader {
     nballerina::Variable readGlobalVar();
     nballerina::Operand readOperand();
     nballerina::Variable readLocalVar();
+    nballerina::MappingConstructorKeyValue readMappingConstructorKeyValue();
     nballerina::TypeDescInsn *readTypeDescInsn();
     nballerina::StructureInsn *readStructureInsn();
     void readInsn(std::shared_ptr<nballerina::BasicBlock> basicBlock);

--- a/compiler/BIRReader.h
+++ b/compiler/BIRReader.h
@@ -62,7 +62,7 @@ class BIRReader {
     nballerina::Variable readGlobalVar();
     nballerina::Operand readOperand();
     nballerina::Variable readLocalVar();
-    nballerina::MapConstrctKeyValue readMappingConstructorKeyValue();
+    std::unique_ptr<nballerina::MapConstruct> readMapConstructor();
     nballerina::TypeDescInsn *readTypeDescInsn();
     nballerina::StructureInsn *readStructureInsn();
     void readInsn(std::shared_ptr<nballerina::BasicBlock> basicBlock);

--- a/compiler/BIRReader.h
+++ b/compiler/BIRReader.h
@@ -62,7 +62,7 @@ class BIRReader {
     nballerina::Variable readGlobalVar();
     nballerina::Operand readOperand();
     nballerina::Variable readLocalVar();
-    std::unique_ptr<nballerina::MapConstruct> readMapConstructor();
+    nballerina::MapConstruct readMapConstructor();
     nballerina::TypeDescInsn *readTypeDescInsn();
     nballerina::StructureInsn *readStructureInsn();
     void readInsn(std::shared_ptr<nballerina::BasicBlock> basicBlock);

--- a/compiler/Clang-tidy.cmake
+++ b/compiler/Clang-tidy.cmake
@@ -9,5 +9,6 @@ if(NOT CLANG_TIDY_EXE)
 else() 
     message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}") 
     set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "--use-color=1" "-checks=*,-fuchsia-*,-google-*,-llvmlibc-*,\
-        -modernize-use-trailing-return-type, -hicpp-named-parameter, -readability-named-parameter")
+        -modernize-use-trailing-return-type, -hicpp-named-parameter, -readability-named-parameter, \
+        -cppcoreguidelines-pro-bounds-array-to-pointer-decay, -hicpp-no-array-decay")
 endif()

--- a/compiler/codegen/ConstantLoadInsn.cpp
+++ b/compiler/codegen/ConstantLoadInsn.cpp
@@ -63,7 +63,11 @@ void ConstantLoadInsn::translate(LLVMModuleRef &modRef) {
         break;
     }
     case TYPE_TAG_BOOLEAN: {
-        constRef = LLVMConstInt(LLVMInt8Type(), std::get<bool>(value), 0);
+        if (std::get<bool>(value)) {
+            constRef = LLVMConstInt(LLVMInt8Type(), 1, 0);
+        } else {
+            constRef = LLVMConstInt(LLVMInt8Type(), 0, 0);
+        }
         break;
     }
     case TYPE_TAG_STRING:

--- a/compiler/codegen/Package.cpp
+++ b/compiler/codegen/Package.cpp
@@ -268,4 +268,18 @@ LLVMValueRef Package::getMapIntStoreDeclaration(LLVMModuleRef &modRef) {
     return mapStoreFunc;
 }
 
+LLVMValueRef Package::getMapSpreadFieldDeclaration(LLVMModuleRef &modRef) {
+    const auto *externalFunctionName = "map_spread_field_init";
+
+    LLVMValueRef func = getFunctionRef(externalFunctionName);
+    if (func != nullptr) {
+        return func;
+    }
+    LLVMTypeRef paramTypes[] = {LLVMPointerType(LLVMInt8Type(), 0), LLVMPointerType(LLVMInt8Type(), 0)};
+    LLVMTypeRef funcType = LLVMFunctionType(LLVMVoidType(), paramTypes, 2, 0);
+    func = LLVMAddFunction(modRef, externalFunctionName, funcType);
+    addFunctionRef(externalFunctionName, func);
+    return func;
+}
+
 } // namespace nballerina

--- a/compiler/codegen/Package.cpp
+++ b/compiler/codegen/Package.cpp
@@ -200,15 +200,15 @@ void Package::applyStringOffsetRelocations(LLVMModuleRef &modRef) {
     for (const auto &element : structElementStoreInst) {
         const std::string &typeString = element.first;
         size_t finalOrigOffset = strBuilder->getOffset(element.first);
-        offsetStringPair.push_back(std::make_pair(finalOrigOffset, typeString));
+        offsetStringPair.emplace_back(finalOrigOffset, typeString);
     }
 
     // creating the concat string to store in the global address space(string table
     // global pointer)
     std::string concatString;
     std::sort(offsetStringPair.begin(), offsetStringPair.end());
-    for (unsigned int i = 0; i < offsetStringPair.size(); i++) {
-        concatString.append(offsetStringPair[i].second);
+    for (const auto &pair : offsetStringPair) {
+        concatString.append(pair.second);
     }
 
     for (const auto &element : structElementStoreInst) {
@@ -224,7 +224,7 @@ void Package::applyStringOffsetRelocations(LLVMModuleRef &modRef) {
     LLVMValueRef createAddrsSpace = LLVMAddGlobalInAddressSpace(modRef, arraType, STRING_TABLE_NAME.c_str(), 0);
     globalVarRefs.insert({STRING_TABLE_NAME, createAddrsSpace});
 
-    LLVMValueRef constString = LLVMConstString(concatString.c_str(), concatString.size(), false);
+    LLVMValueRef constString = LLVMConstString(concatString.c_str(), concatString.size(), 0);
     // Initializing global address space with generated string(concat all the
     // strings from string builder table).
     LLVMSetInitializer(createAddrsSpace, constString);

--- a/compiler/codegen/Package.cpp
+++ b/compiler/codegen/Package.cpp
@@ -254,4 +254,22 @@ void Package::insertGlobalVar(Variable var) {
     globalVars.insert(std::pair<std::string, Variable>(var.getName(), std::move(var)));
 }
 
+// Declaration for map<int> type store function
+LLVMValueRef Package::getMapIntStoreDeclaration(LLVMModuleRef &modRef) {
+    const auto *externalFunctionName= "map_store_int";
+
+    LLVMValueRef mapStoreFunc = getFunctionRef(externalFunctionName);
+    if (mapStoreFunc != nullptr) {
+        return mapStoreFunc;
+    }
+    LLVMTypeRef int32PtrType = LLVMPointerType(LLVMInt32Type(), 0);
+    LLVMTypeRef charArrayPtrType = LLVMPointerType(LLVMInt8Type(), 0);
+    LLVMTypeRef memPtrType = LLVMPointerType(LLVMInt8Type(), 0);
+    LLVMTypeRef paramTypes[] = {memPtrType, charArrayPtrType, int32PtrType};
+    LLVMTypeRef funcType = LLVMFunctionType(LLVMVoidType(), paramTypes, 3, 0);
+    mapStoreFunc = LLVMAddFunction(modRef, externalFunctionName, funcType);
+    addFunctionRef(externalFunctionName, mapStoreFunc);
+    return mapStoreFunc;
+}
+
 } // namespace nballerina

--- a/compiler/codegen/Package.cpp
+++ b/compiler/codegen/Package.cpp
@@ -122,7 +122,7 @@ void Package::translate(LLVMModuleRef &modRef) {
     for (auto const &it : globalVars) {
         auto const &globVar = it.second;
         LLVMTypeRef varTyperef = getLLVMTypeOfType(globVar.getType());
-        const std::string varName = globVar.getName();
+        const auto &varName = globVar.getName();
         // emit/adding the global variable.
         llvm::Constant *initValue = llvm::Constant::getNullValue(llvm::unwrap(varTyperef));
         auto gVar =
@@ -215,12 +215,8 @@ void Package::applyStringOffsetRelocations(LLVMModuleRef &modRef) {
         size_t finalOrigOffset = strBuilder->getOffset(element.first);
         LLVMValueRef tempVal = LLVMConstInt(LLVMInt32Type(), finalOrigOffset, 0);
         for (const auto &insn : element.second) {
-            LLVMValueRef constOperand;
-            llvm::GetElementPtrInst *GEPInst = llvm::dyn_cast<llvm::GetElementPtrInst>(llvm::unwrap(insn));
-            if (GEPInst)
-                constOperand = LLVMGetOperand(insn, 1);
-            else
-                constOperand = LLVMGetOperand(insn, 0);
+            auto *GEPInst = llvm::dyn_cast<llvm::GetElementPtrInst>(llvm::unwrap(insn));
+            LLVMValueRef constOperand = (GEPInst != nullptr) ? LLVMGetOperand(insn, 1) : LLVMGetOperand(insn, 0);
             LLVMReplaceAllUsesWith(constOperand, tempVal);
         }
     }
@@ -250,13 +246,13 @@ std::optional<Variable> Package::getGlobalVariable(const std::string &name) cons
     return varIt->second;
 }
 
-void Package::insertGlobalVar(Variable var) {
-    globalVars.insert(std::pair<std::string, Variable>(var.getName(), std::move(var)));
+void Package::insertGlobalVar(const Variable &var) {
+    globalVars.insert(std::pair<std::string, Variable>(var.getName(), var));
 }
 
 // Declaration for map<int> type store function
 LLVMValueRef Package::getMapIntStoreDeclaration(LLVMModuleRef &modRef) {
-    const auto *externalFunctionName= "map_store_int";
+    const auto *externalFunctionName = "map_store_int";
 
     LLVMValueRef mapStoreFunc = getFunctionRef(externalFunctionName);
     if (mapStoreFunc != nullptr) {

--- a/compiler/codegen/StructureInsn.cpp
+++ b/compiler/codegen/StructureInsn.cpp
@@ -18,6 +18,7 @@
 
 #include "StructureInsn.h"
 #include "Function.h"
+#include "MapInsns.h"
 #include "Operand.h"
 #include "Package.h"
 #include "Types.h"
@@ -30,8 +31,9 @@ using namespace llvm;
 
 namespace nballerina {
 
-StructureInsn::StructureInsn(const Operand &lhs, std::shared_ptr<BasicBlock> currentBB)
-    : NonTerminatorInsn(lhs, std::move(currentBB)) {}
+StructureInsn::StructureInsn(const Operand &lhs, std::shared_ptr<BasicBlock> currentBB,
+                             std::vector<MappingConstructorKeyValue> initValues)
+    : NonTerminatorInsn(lhs, std::move(currentBB)), initValues(std::move(initValues)) {}
 
 void StructureInsn::translate(LLVMModuleRef &modRef) {
 

--- a/compiler/codegen/StructureInsn.cpp
+++ b/compiler/codegen/StructureInsn.cpp
@@ -53,7 +53,7 @@ void StructureInsn::translate(LLVMModuleRef &modRef) {
     }
     mapInstructionTranslate(*lhsVar, modRef);
 
-    if (initValues.size() == 0) {
+    if (initValues.empty()) {
         return;
     }
 

--- a/compiler/codegen/StructureInsn.cpp
+++ b/compiler/codegen/StructureInsn.cpp
@@ -75,14 +75,14 @@ void StructureInsn::mapInitTranslate(const Variable &lhsVar, LLVMModuleRef &modR
     for (const auto &initValue : initValues) {
         const auto &initstruct = initValue.getInitValStruct();
         if (initValue.getKind() == Spread_Field_Kind) {
-            const auto &expr = std::get<SpreadField>(initstruct).getExpr();
+            const auto &expr = std::get<MapConstruct::SpreadField>(initstruct).getExpr();
             LLVMValueRef argOpValueRef[] = {funcObj.createTempVariable(getLhsOperand()),
                                             funcObj.createTempVariable(expr)};
             LLVMBuildCall(builder, mapSpreadFieldFunc, argOpValueRef, 2, "");
             continue;
         }
         // For Key_Value_Kind
-        const auto &keyVal = std::get<KeyValue>(initstruct);
+        const auto &keyVal = std::get<MapConstruct::KeyValue>(initstruct);
         MapStoreInsn::codeGenMapStore(builder, mapStoreFunc, funcObj.createTempVariable(getLhsOperand()),
                                       funcObj.createTempVariable(keyVal.getKey()),
                                       funcObj.getLLVMLocalOrGlobalVar(keyVal.getValue()));

--- a/compiler/codegen/StructureInsn.cpp
+++ b/compiler/codegen/StructureInsn.cpp
@@ -51,20 +51,26 @@ void StructureInsn::translate(LLVMModuleRef &modRef) {
     if (structType != TYPE_TAG_MAP) {
         llvm_unreachable("Only Map type structs are currently supported");
     }
-    mapInstructionTranslate(*lhsVar, modRef);
+    mapCreateTranslate(*lhsVar, modRef);
 
     if (initValues.empty()) {
         return;
     }
 
+    mapInitTranslate(*lhsVar, modRef);
+}
+
+void StructureInsn::mapInitTranslate(const Variable &lhsVar, LLVMModuleRef &modRef) {
+
     // Only handle Int type
-    if (lhsVar->getType().getMemberTypeTag() != TYPE_TAG_INT) {
+    if (lhsVar.getType().getMemberTypeTag() != TYPE_TAG_INT) {
         llvm_unreachable("Only int type maps are currently supported");
     }
 
     // Codegen for map<int> type store
     LLVMValueRef mapStoreFunc = getPackageMutableRef().getMapIntStoreDeclaration(modRef);
     LLVMValueRef mapSpreadFieldFunc = getPackageMutableRef().getMapSpreadFieldDeclaration(modRef);
+    const auto &funcObj = getFunctionRef();
     LLVMBuilderRef builder = funcObj.getLLVMBuilder();
     for (const auto &initValue : initValues) {
         const auto &initstruct = initValue.getInitValStruct();
@@ -83,7 +89,7 @@ void StructureInsn::translate(LLVMModuleRef &modRef) {
     }
 }
 
-void StructureInsn::mapInstructionTranslate(const Variable &lhsVar, LLVMModuleRef &modRef) {
+void StructureInsn::mapCreateTranslate(const Variable &lhsVar, LLVMModuleRef &modRef) {
 
     const auto &funcObj = getFunctionRef();
     LLVMBuilderRef builder = funcObj.getLLVMBuilder();
@@ -94,7 +100,7 @@ void StructureInsn::mapInstructionTranslate(const Variable &lhsVar, LLVMModuleRe
     TypeTag memberTypeTag = mapType.getMemberTypeTag();
     // Only handle Int type
     if (memberTypeTag != TYPE_TAG_INT) {
-        llvm_unreachable("Only int type maps are currently supporte");
+        llvm_unreachable("Only int type maps are currently supported");
     }
 
     // Codegen for Map of Int type

--- a/compiler/codegen/StructureInsn.cpp
+++ b/compiler/codegen/StructureInsn.cpp
@@ -65,7 +65,7 @@ void StructureInsn::translate(LLVMModuleRef &modRef) {
     // Codegen for map<int> type store
     LLVMValueRef mapStoreFunc = getPackageMutableRef().getMapIntStoreDeclaration(modRef);
     LLVMValueRef mapSpreadFieldFunc = getPackageMutableRef().getMapSpreadFieldDeclaration(modRef);
-    auto builder = funcObj.getLLVMBuilder();
+    LLVMBuilderRef builder = funcObj.getLLVMBuilder();
     for (const auto &initValue : initValues) {
         const auto &initstruct = initValue.getInitValStruct();
         if (initValue.getKind() == Spread_Field_Kind) {

--- a/compiler/codegen/TypeCastInsn.cpp
+++ b/compiler/codegen/TypeCastInsn.cpp
@@ -164,8 +164,9 @@ std::string_view TypeCastInsn::typeStringMangleName(LLVMTypeRef valType, TypeTag
     }
     case TYPE_TAG_ARRAY: {
         // TODO Need to add Size of the array.
-        if (unwrap(valType)->getPointerElementType()->isIntegerTy())
+        if (unwrap(valType)->getPointerElementType()->isIntegerTy()){
             return "__AI";
+        }
         return "__A";
     }
     case TYPE_TAG_ANY: {

--- a/compiler/codegen/Types.cpp
+++ b/compiler/codegen/Types.cpp
@@ -20,11 +20,10 @@
 
 namespace nballerina {
 
-Type::Type(TypeTag type, std::string namep, int flagsp, TypeTag memberType)
-    : type(type), name(std::move(namep)), flags(flagsp), memberType(memberType) {}
+Type::Type(TypeTag type, std::string namep, TypeTag memberType)
+    : type(type), name(std::move(namep)), memberType(memberType) {}
 
-Type::Type(TypeTag type, std::string namep, int flagsp)
-    : type(type), name(std::move(namep)), flags(flagsp) {}
+Type::Type(TypeTag type, std::string namep) : type(type), name(std::move(namep)) {}
 
 TypeTag Type::getTypeTag() const { return type; }
 const std::string &Type::getName() const { return name; }

--- a/compiler/include/Function.h
+++ b/compiler/include/Function.h
@@ -91,11 +91,11 @@ class Function : public Debuggable, public Translatable {
     LLVMValueRef createTempVariable(const Operand &op) const;
 
     void patchBasicBlocks();
-    void insertParam(FunctionParam param);
+    void insertParam(const FunctionParam &param);
     void setRestParam(RestParam param);
     void setReturnVar(const Variable &var);
     void insertLocalVar(const Variable &var);
-    void insertBasicBlock(std::shared_ptr<BasicBlock> bb);
+    void insertBasicBlock(const std::shared_ptr<BasicBlock> &bb);
     void insertBranchComparisonValue(const std::string &lhsName, LLVMValueRef compRef);
     void setLLVMBuilder(LLVMBuilderRef builder);
     void setLLVMFunctionValue(LLVMValueRef funcRef);

--- a/compiler/include/MapInsns.h
+++ b/compiler/include/MapInsns.h
@@ -23,24 +23,26 @@
 
 namespace nballerina {
 
-enum MappingConstructorBodyKind { Spread_Field_Kind = 0, Key_Value_Kind = 1 };
+enum MapConstrctBodyKind { Spread_Field_Kind = 0, Key_Value_Kind = 1 };
 
-class MappingConstructorKeyValue {
+class MapConstrctKeyValue {
   private:
     Operand keyOp;
     Operand valueOp;
 
   public:
-    MappingConstructorKeyValue() = delete;
-    MappingConstructorKeyValue(const Operand &key, const Operand &value) : keyOp(key), valueOp(value) {}
-    ~MappingConstructorKeyValue() = default;
+    MapConstrctKeyValue() = delete;
+    MapConstrctKeyValue(const Operand &key, const Operand &value) : keyOp(key), valueOp(value) {}
+    ~MapConstrctKeyValue() = default;
+
+    const Operand &getKey() const { return keyOp; }
+    const Operand &getValue() const { return valueOp; }
 };
 
 class MapStoreInsn : public NonTerminatorInsn {
   private:
     Operand keyOp;
     Operand rhsOp;
-    LLVMValueRef getMapIntStoreDeclaration(LLVMModuleRef &modRef);
 
   public:
     MapStoreInsn() = delete;
@@ -48,6 +50,8 @@ class MapStoreInsn : public NonTerminatorInsn {
     ~MapStoreInsn() = default;
 
     void translate(LLVMModuleRef &modRef) final;
+    static void codeGenMapStore(LLVMBuilderRef builder, LLVMValueRef mapStoreFunc, LLVMValueRef map, LLVMValueRef key,
+                                LLVMValueRef value);
 };
 } // namespace nballerina
 

--- a/compiler/include/MapInsns.h
+++ b/compiler/include/MapInsns.h
@@ -20,23 +20,48 @@
 #define __MAPSTOREINSN__H__
 
 #include "NonTerminatorInsn.h"
+#include <variant>
 
 namespace nballerina {
 
 enum MapConstrctBodyKind { Spread_Field_Kind = 0, Key_Value_Kind = 1 };
 
-class MapConstrctKeyValue {
+class MapConstruct {
+  private:
+    MapConstrctBodyKind kind;
+
+  public:
+    MapConstruct() = delete;
+    MapConstruct(MapConstrctBodyKind kind) : kind(kind) {}
+    virtual ~MapConstruct() = default;
+    MapConstrctBodyKind getKind() { return kind; }
+};
+
+class MapConstructKeyValue : public MapConstruct {
   private:
     Operand keyOp;
     Operand valueOp;
 
   public:
-    MapConstrctKeyValue() = delete;
-    MapConstrctKeyValue(const Operand &key, const Operand &value) : keyOp(key), valueOp(value) {}
-    ~MapConstrctKeyValue() = default;
+    MapConstructKeyValue() = delete;
+    MapConstructKeyValue(const Operand &key, const Operand &value)
+        : MapConstruct(Key_Value_Kind), keyOp(key), valueOp(value) {}
+    ~MapConstructKeyValue() = default;
 
     const Operand &getKey() const { return keyOp; }
     const Operand &getValue() const { return valueOp; }
+};
+
+class MapConstructSpreadField : public MapConstruct {
+  private:
+    Operand expr;
+
+  public:
+    MapConstructSpreadField() = delete;
+    MapConstructSpreadField(const Operand &expr) : MapConstruct(Spread_Field_Kind), expr(expr) {}
+    ~MapConstructSpreadField() = default;
+
+    const Operand &getExpr() const { return expr; }
 };
 
 class MapStoreInsn : public NonTerminatorInsn {

--- a/compiler/include/MapInsns.h
+++ b/compiler/include/MapInsns.h
@@ -22,6 +22,20 @@
 #include "NonTerminatorInsn.h"
 
 namespace nballerina {
+
+enum MappingConstructorBodyKind { Spread_Field_Kind = 0, Key_Value_Kind = 1 };
+
+class MappingConstructorKeyValue {
+  private:
+    Operand keyOp;
+    Operand valueOp;
+
+  public:
+    MappingConstructorKeyValue() = delete;
+    MappingConstructorKeyValue(const Operand &key, const Operand &value) : keyOp(key), valueOp(value) {}
+    ~MappingConstructorKeyValue() = default;
+};
+
 class MapStoreInsn : public NonTerminatorInsn {
   private:
     Operand keyOp;

--- a/compiler/include/MapInsns.h
+++ b/compiler/include/MapInsns.h
@@ -26,42 +26,44 @@ namespace nballerina {
 
 enum MapConstrctBodyKind { Spread_Field_Kind = 0, Key_Value_Kind = 1 };
 
-class MapConstruct {
-  private:
-    MapConstrctBodyKind kind;
-
-  public:
-    MapConstruct() = delete;
-    MapConstruct(MapConstrctBodyKind kind) : kind(kind) {}
-    virtual ~MapConstruct() = default;
-    MapConstrctBodyKind getKind() { return kind; }
-};
-
-class MapConstructKeyValue : public MapConstruct {
+class KeyValue {
   private:
     Operand keyOp;
     Operand valueOp;
 
   public:
-    MapConstructKeyValue() = delete;
-    MapConstructKeyValue(const Operand &key, const Operand &value)
-        : MapConstruct(Key_Value_Kind), keyOp(key), valueOp(value) {}
-    ~MapConstructKeyValue() = default;
+    KeyValue() = delete;
+    KeyValue(const Operand &key, const Operand &value) : keyOp(key), valueOp(value) {}
+    ~KeyValue() = default;
 
     const Operand &getKey() const { return keyOp; }
     const Operand &getValue() const { return valueOp; }
 };
 
-class MapConstructSpreadField : public MapConstruct {
+class SpreadField {
   private:
     Operand expr;
 
   public:
-    MapConstructSpreadField() = delete;
-    MapConstructSpreadField(const Operand &expr) : MapConstruct(Spread_Field_Kind), expr(expr) {}
-    ~MapConstructSpreadField() = default;
+    SpreadField() = delete;
+    SpreadField(const Operand &expr) : expr(expr) {}
+    ~SpreadField() = default;
 
     const Operand &getExpr() const { return expr; }
+};
+
+class MapConstruct {
+  private:
+    MapConstrctBodyKind kind;
+    std::variant<KeyValue, SpreadField> initValueStruct;
+
+  public:
+    MapConstruct() = delete;
+    MapConstruct(KeyValue initVal) : kind(Key_Value_Kind), initValueStruct(initVal) {}
+    MapConstruct(SpreadField initVal) : kind(Spread_Field_Kind), initValueStruct(initVal) {}
+    virtual ~MapConstruct() = default;
+    MapConstrctBodyKind getKind() const { return kind; }
+    const std::variant<KeyValue, SpreadField> &getInitValStruct() const { return initValueStruct; }
 };
 
 class MapStoreInsn : public NonTerminatorInsn {

--- a/compiler/include/MapInsns.h
+++ b/compiler/include/MapInsns.h
@@ -26,33 +26,33 @@ namespace nballerina {
 
 enum MapConstrctBodyKind { Spread_Field_Kind = 0, Key_Value_Kind = 1 };
 
-class KeyValue {
-  private:
-    Operand keyOp;
-    Operand valueOp;
-
-  public:
-    KeyValue() = delete;
-    KeyValue(const Operand &key, const Operand &value) : keyOp(key), valueOp(value) {}
-    ~KeyValue() = default;
-
-    const Operand &getKey() const { return keyOp; }
-    const Operand &getValue() const { return valueOp; }
-};
-
-class SpreadField {
-  private:
-    Operand expr;
-
-  public:
-    SpreadField() = delete;
-    SpreadField(const Operand &expr) : expr(expr) {}
-    ~SpreadField() = default;
-
-    const Operand &getExpr() const { return expr; }
-};
-
 class MapConstruct {
+  public:
+    class SpreadField {
+      private:
+        Operand expr;
+
+      public:
+        SpreadField() = delete;
+        SpreadField(const Operand &expr) : expr(expr) {}
+        ~SpreadField() = default;
+
+        const Operand &getExpr() const { return expr; }
+    };
+    class KeyValue {
+      private:
+        Operand keyOp;
+        Operand valueOp;
+
+      public:
+        KeyValue() = delete;
+        KeyValue(const Operand &key, const Operand &value) : keyOp(key), valueOp(value) {}
+        ~KeyValue() = default;
+
+        const Operand &getKey() const { return keyOp; }
+        const Operand &getValue() const { return valueOp; }
+    };
+
   private:
     MapConstrctBodyKind kind;
     std::variant<KeyValue, SpreadField> initValueStruct;

--- a/compiler/include/Package.h
+++ b/compiler/include/Package.h
@@ -75,6 +75,7 @@ class Package : public Translatable {
     // Return is optional only because we need to support _bal_resul
     // ToDo remove optional when support for _bal_result is removed
     std::optional<Variable> getGlobalVariable(const std::string &name) const;
+    LLVMValueRef getMapIntStoreDeclaration(LLVMModuleRef &modRef);
 
     void addToStrTable(std::string_view name);
     void setOrgName(std::string orgName);

--- a/compiler/include/Package.h
+++ b/compiler/include/Package.h
@@ -76,6 +76,7 @@ class Package : public Translatable {
     // ToDo remove optional when support for _bal_result is removed
     std::optional<Variable> getGlobalVariable(const std::string &name) const;
     LLVMValueRef getMapIntStoreDeclaration(LLVMModuleRef &modRef);
+    LLVMValueRef getMapSpreadFieldDeclaration(LLVMModuleRef &modRef);
 
     void addToStrTable(std::string_view name);
     void setOrgName(std::string orgName);

--- a/compiler/include/Package.h
+++ b/compiler/include/Package.h
@@ -82,7 +82,7 @@ class Package : public Translatable {
     void setPackageName(std::string pkgName);
     void setVersion(std::string verName);
     void setSrcFileName(std::string srcFileName);
-    void insertGlobalVar(Variable var);
+    void insertGlobalVar(const Variable &var);
     void insertFunction(const std::shared_ptr<Function> &function);
     void addFunctionRef(const std::string &arrayName, LLVMValueRef functionRef);
     void addStringOffsetRelocationEntry(const std::string &eleType, LLVMValueRef storeInsn);

--- a/compiler/include/StructureInsn.h
+++ b/compiler/include/StructureInsn.h
@@ -27,11 +27,11 @@ namespace nballerina {
 // Forward Declaration
 class Operand;
 class Variable;
-class MapConstrctKeyValue;
+class MapConstruct;
 
 class StructureInsn : public NonTerminatorInsn {
   private:
-    std::vector<MapConstrctKeyValue> initValues;
+    std::vector<std::unique_ptr<MapConstruct>> initValues;
     void mapInstructionTranslate(const Variable &lhsVar, LLVMModuleRef &modRef);
     LLVMValueRef getNewMapIntDeclaration(LLVMModuleRef &modRef);
 
@@ -39,7 +39,7 @@ class StructureInsn : public NonTerminatorInsn {
     StructureInsn() = delete;
     StructureInsn(const Operand &lhs, std::shared_ptr<BasicBlock> currentBB);
     StructureInsn(const Operand &lhs, std::shared_ptr<BasicBlock> currentBB,
-                  std::vector<MapConstrctKeyValue> initValues);
+                  std::vector<std::unique_ptr<MapConstruct>> initValues);
     ~StructureInsn() = default;
 
     void translate(LLVMModuleRef &modRef) final;

--- a/compiler/include/StructureInsn.h
+++ b/compiler/include/StructureInsn.h
@@ -27,18 +27,19 @@ namespace nballerina {
 // Forward Declaration
 class Operand;
 class Variable;
-class MappingConstructorKeyValue;
+class MapConstrctKeyValue;
 
 class StructureInsn : public NonTerminatorInsn {
   private:
-    std::vector<MappingConstructorKeyValue> initValues;
-    void mapInsnTranslate(const Variable &lhsVar, LLVMModuleRef &modRef);
+    std::vector<MapConstrctKeyValue> initValues;
+    void mapInstructionTranslate(const Variable &lhsVar, LLVMModuleRef &modRef);
     LLVMValueRef getNewMapIntDeclaration(LLVMModuleRef &modRef);
 
   public:
     StructureInsn() = delete;
+    StructureInsn(const Operand &lhs, std::shared_ptr<BasicBlock> currentBB);
     StructureInsn(const Operand &lhs, std::shared_ptr<BasicBlock> currentBB,
-                  std::vector<MappingConstructorKeyValue> initValues);
+                  std::vector<MapConstrctKeyValue> initValues);
     ~StructureInsn() = default;
 
     void translate(LLVMModuleRef &modRef) final;

--- a/compiler/include/StructureInsn.h
+++ b/compiler/include/StructureInsn.h
@@ -20,21 +20,25 @@
 #define __STRUCTUREINSN__H__
 
 #include "NonTerminatorInsn.h"
+#include <vector>
 
 namespace nballerina {
 
 // Forward Declaration
 class Operand;
 class Variable;
+class MappingConstructorKeyValue;
 
 class StructureInsn : public NonTerminatorInsn {
   private:
+    std::vector<MappingConstructorKeyValue> initValues;
     void mapInsnTranslate(const Variable &lhsVar, LLVMModuleRef &modRef);
     LLVMValueRef getNewMapIntDeclaration(LLVMModuleRef &modRef);
 
   public:
     StructureInsn() = delete;
-    StructureInsn(const Operand &lhs, std::shared_ptr<BasicBlock> currentBB);
+    StructureInsn(const Operand &lhs, std::shared_ptr<BasicBlock> currentBB,
+                  std::vector<MappingConstructorKeyValue> initValues);
     ~StructureInsn() = default;
 
     void translate(LLVMModuleRef &modRef) final;

--- a/compiler/include/StructureInsn.h
+++ b/compiler/include/StructureInsn.h
@@ -31,7 +31,7 @@ class MapConstruct;
 
 class StructureInsn : public NonTerminatorInsn {
   private:
-    std::vector<std::unique_ptr<MapConstruct>> initValues;
+    std::vector<MapConstruct> initValues;
     void mapInstructionTranslate(const Variable &lhsVar, LLVMModuleRef &modRef);
     LLVMValueRef getNewMapIntDeclaration(LLVMModuleRef &modRef);
 
@@ -39,7 +39,7 @@ class StructureInsn : public NonTerminatorInsn {
     StructureInsn() = delete;
     StructureInsn(const Operand &lhs, std::shared_ptr<BasicBlock> currentBB);
     StructureInsn(const Operand &lhs, std::shared_ptr<BasicBlock> currentBB,
-                  std::vector<std::unique_ptr<MapConstruct>> initValues);
+                  std::vector<MapConstruct> initValues);
     ~StructureInsn() = default;
 
     void translate(LLVMModuleRef &modRef) final;

--- a/compiler/include/StructureInsn.h
+++ b/compiler/include/StructureInsn.h
@@ -32,7 +32,8 @@ class MapConstruct;
 class StructureInsn : public NonTerminatorInsn {
   private:
     std::vector<MapConstruct> initValues;
-    void mapInstructionTranslate(const Variable &lhsVar, LLVMModuleRef &modRef);
+    void mapCreateTranslate(const Variable &lhsVar, LLVMModuleRef &modRef);
+    void mapInitTranslate(const Variable &lhsVar, LLVMModuleRef &modRef);
     LLVMValueRef getNewMapIntDeclaration(LLVMModuleRef &modRef);
 
   public:

--- a/compiler/include/TypeCastInsn.h
+++ b/compiler/include/TypeCastInsn.h
@@ -35,7 +35,7 @@ class TypeCastInsn : public NonTerminatorInsn {
     LLVMValueRef generateBoxValueFunc(LLVMModuleRef &modRef, LLVMTypeRef paramTypeRef, TypeTag typeTag);
     LLVMValueRef isSameType(LLVMModuleRef &modRef, LLVMValueRef lhsRef, LLVMValueRef rhsRef);
     static bool isBoxValueSupport(TypeTag typeTag);
-    std::string_view typeStringMangleName(LLVMTypeRef valType, TypeTag typeTag);
+    static std::string_view typeStringMangleName(LLVMTypeRef valType, TypeTag typeTag);
 
   public:
     TypeCastInsn() = delete;

--- a/compiler/include/Types.h
+++ b/compiler/include/Types.h
@@ -85,13 +85,12 @@ class Type {
   private:
     TypeTag type;
     std::string name;
-    int flags;
     std::optional<TypeTag> memberType;
 
   public:
     Type() = delete;
-    Type(TypeTag type, std::string name, int flags);
-    Type(TypeTag type, std::string name, int flags, TypeTag memberType);
+    Type(TypeTag type, std::string name);
+    Type(TypeTag type, std::string name, TypeTag memberType);
     virtual ~Type() = default;
 
     TypeTag getTypeTag() const;

--- a/runtime/src/bal_map.rs
+++ b/runtime/src/bal_map.rs
@@ -19,6 +19,14 @@ pub mod map {
         pub fn insert(&mut self, key: &str, member: i32) {
             self.map.insert(String::from(key), member);
         }
+
+        // Insert with spread field expression
+        pub fn insert_spread_field(&mut self, expr: &BalMapInt) {
+            for (key, value) in expr.map.iter() {
+                self.map.insert(String::from(key), *value);
+            }
+        }
+
         // test functions
         pub fn length(&self) -> usize {
             self.map.len()

--- a/runtime/src/bal_map.rs
+++ b/runtime/src/bal_map.rs
@@ -22,9 +22,7 @@ pub mod map {
 
         // Insert with spread field expression
         pub fn insert_spread_field(&mut self, expr: &BalMapInt) {
-            for (key, value) in expr.map.iter() {
-                self.map.insert(String::from(key), *value);
-            }
+            self.map.extend(expr.map.clone().into_iter());
         }
 
         // test functions

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -232,3 +232,23 @@ pub extern "C" fn unbox_bal_bool(ptr: *mut f64) {
         Box::from_raw(ptr);
     }
 }
+
+#[no_mangle]
+pub extern "C" fn map_spread_field_init(ptr_source: *mut BalMapInt, ptr_expr: *mut BalMapInt) {
+    // Load source BalMap from pointer
+    let map_src = unsafe {
+        assert!(!ptr_source.is_null());
+        &mut *ptr_source
+    };
+    // Load expr BalMap from pointer
+    let map_expr = unsafe {
+        assert!(!ptr_expr.is_null());
+        &mut *ptr_expr
+    };
+
+    // Insert from spread field expression
+    map_src.insert_spread_field(map_expr);
+
+    // Print length to test functionality
+    println!("length={}", map_src.length());
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -165,20 +165,20 @@ pub extern "C" fn map_deint_int(ptr: *mut BalMapInt) {
 #[no_mangle]
 pub extern "C" fn map_store_int(ptr: *mut BalMapInt, key: *const c_char, member_ptr: *const i32) {
     // Load BalMap from pointer
+    assert!(!ptr.is_null());
     let bal_map = unsafe {
-        assert!(!ptr.is_null());
         &mut *ptr
     };
     // Load Key C string
+    assert!(!key.is_null());
     let key = unsafe {
-        assert!(!key.is_null());
         CStr::from_ptr(key)
     };
     let key_str = key.to_str().unwrap();
 
     // Load member value
+    assert!(!member_ptr.is_null());
     let member = unsafe {
-        assert!(!member_ptr.is_null());
         slice::from_raw_parts(member_ptr, 1)
     };
     // Insert new field
@@ -236,16 +236,15 @@ pub extern "C" fn unbox_bal_bool(ptr: *mut f64) {
 #[no_mangle]
 pub extern "C" fn map_spread_field_init(ptr_source: *mut BalMapInt, ptr_expr: *mut BalMapInt) {
     // Load source BalMap from pointer
+    assert!(!ptr_source.is_null());
     let map_src = unsafe {
-        assert!(!ptr_source.is_null());
         &mut *ptr_source
     };
     // Load expr BalMap from pointer
+    assert!(!ptr_expr.is_null());
     let map_expr = unsafe {
-        assert!(!ptr_expr.is_null());
         &mut *ptr_expr
     };
-
     // Insert from spread field expression
     map_src.insert_spread_field(map_expr);
 

--- a/test/map/mapBasic.bal
+++ b/test/map/mapBasic.bal
@@ -1,5 +1,4 @@
 // RUN: "%testRunScript" %s %nballerinacc "%java_path" | filecheck %s
-int _bal_result = 0;
 public function main() {
     map<int> marks = {};
     marks["jon"] = 60;

--- a/test/map/mapGlobal.bal
+++ b/test/map/mapGlobal.bal
@@ -1,7 +1,5 @@
 // RUN: "%testRunScript" %s %nballerinacc "%java_path" | filecheck %s
 
-int _bal_result = 0;
-
 map<int> marks = {};
 int value = 60;
 string key = "";

--- a/test/map/mapInit.bal
+++ b/test/map/mapInit.bal
@@ -1,7 +1,5 @@
 // RUN: "%testRunScript" %s %nballerinacc "%java_path" | filecheck %s
-int _bal_result = 0;
 public function main() {
     map<int> marks = {sam: 50, jon: 60};
-    _bal_result = 0;
 }
 // CHECK: length=2

--- a/test/map/mapInitAdvance.bal
+++ b/test/map/mapInitAdvance.bal
@@ -1,9 +1,7 @@
 // RUN: "%testRunScript" %s %nballerinacc "%java_path" | filecheck %s
-int _bal_result = 0;
 public function main() {
     int dan = 70;
     string best = "sam";
     map<int> marks = {dan, [best]: 80};
-    _bal_result = 0;
 }
 // CHECK: length=2

--- a/test/map/mapInitAdvance.bal
+++ b/test/map/mapInitAdvance.bal
@@ -1,0 +1,9 @@
+// RUN: "%testRunScript" %s %nballerinacc "%java_path" | filecheck %s
+int _bal_result = 0;
+public function main() {
+    int dan = 70;
+    string best = "sam";
+    map<int> marks = {dan, [best]: 80};
+    _bal_result = 0;
+}
+// CHECK: length=2

--- a/test/map/mapInitSpreadField.bal
+++ b/test/map/mapInitSpreadField.bal
@@ -1,0 +1,7 @@
+// RUN: "%testRunScript" %s %nballerinacc "%java_path" | filecheck %s
+public function main() {
+    map<int> boys = {Jake: 80, Steve: 90};
+    map<int> girls = {Amy: 85, Sam: 88};
+    map<int> allMarks = {...boys, ...girls};
+}
+// CHECK: length=4

--- a/test/map/mapInitialization.bal
+++ b/test/map/mapInitialization.bal
@@ -1,0 +1,7 @@
+// RUN: "%testRunScript" %s %nballerinacc "%java_path" | filecheck %s
+int _bal_result = 0;
+public function main() {
+    map<int> marks = {sam: 50, jon: 60};
+    _bal_result = 0;
+}
+// CHECK: length=2

--- a/test/testRunScript.sh
+++ b/test/testRunScript.sh
@@ -24,7 +24,7 @@ $2 $filename-bir-dump  2>nbal_err.log
 if [ -s ./nbal_err.log ]
 then
   echo "nballerinacc error. Error msg: "
-  echo ./nbal_err.log
+  cat ./nbal_err.log
   exit 1
 fi
 
@@ -33,7 +33,7 @@ clang -O0 -o $filename.out $filename-bir-dump.ll -L../../../runtime/target/relea
 if [ -s ./clang_err.log ]
 then
   echo "clang error/warning. Error msg: "
-  echo ./clang_err.log
+  cat ./clang_err.log
   exit 1
 fi
 


### PR DESCRIPTION
## Purpose
Adds support for key/value and spread field initialization of maps (only for `map<int>` types)

Resolves #121 

## Approach
* Key/value initialization is done by calling `map_store` runtime function for each key/value pair
* Spread field initialization via map type is supported
  * The implementation passes the map's reference from the spread field expression to  the runtime; where the fields are copied to the map that is being initialized.

Note: Requires `jballerina-tools-2.0.0-Preview2-nballerina-r2` (updated Ballerina pack) linked in the updated README

## Related PRs
Depends on #180 
