### PR TITLE
Enable cross language LTO for compiled ballerina apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Translate Ballerina IR to LLVM IR.
 
 ## Building from source in Ubuntu 20.04
 ### Prerequisites
-* `sudo apt install build-essential llvm-11-dev cmake cargo python3-pip`
+* `sudo apt install build-essential llvm-11-dev lld-11 cmake cargo python3-pip`
 * `pip3 install lit filecheck`
 
 ### Build steps

--- a/compiler/BIRReader.cpp
+++ b/compiler/BIRReader.cpp
@@ -49,7 +49,7 @@ ReadArrayLoadInsn ReadArrayLoadInsn::readArrayLoadInsn;
 ReadMapStoreInsn ReadMapStoreInsn::readMapStoreInsn;
 ReadMapLoadInsn ReadMapLoadInsn::readMapLoadInsn;
 
-constexpr bool BIRReader::isLittleEndian() {
+bool BIRReader::isLittleEndian() {
     unsigned int val = 1;
     char *c = (char *)&val;
     return (int)*c != 0;

--- a/compiler/BIRReader.h
+++ b/compiler/BIRReader.h
@@ -77,7 +77,7 @@ class BIRReader {
     int32_t readS4be();
     int64_t readS8be();
     double readS8bef();
-    constexpr bool isLittleEndian();
+    bool isLittleEndian();
     static bool ignoreFunction(std::string funcName);
 
   public:

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -32,7 +32,7 @@ set_target_properties( nballerinacc
 )
 
 # We want to build nballerinacc after the Runtime
-add_dependencies(nballerinacc BallerinaRT)
+add_dependencies(nballerinacc libballerina_rt)
 
 # Find and like LLVM static libs
 llvm_map_components_to_libnames(llvm_libs codegen)

--- a/compiler/codegen/ConstantLoadInsn.cpp
+++ b/compiler/codegen/ConstantLoadInsn.cpp
@@ -50,7 +50,7 @@ LLVMValueRef ConstantLoadInsn::getNewString(LLVMModuleRef &modRef) {
     if (addedStringRef != nullptr) {
         return addedStringRef;
     }
-    LLVMTypeRef paramTypes[] = {LLVMPointerType(LLVMInt8Type(), 0), LLVMInt32Type()};
+    LLVMTypeRef paramTypes[] = {LLVMPointerType(LLVMInt8Type(), 0), LLVMInt64Type()};
     LLVMTypeRef funcType = LLVMFunctionType(LLVMPointerType(LLVMInt8Type(), 0), paramTypes, 2, 0);
     addedStringRef = LLVMAddFunction(modRef, newString, funcType);
     getPackageMutableRef().addFunctionRef(newString, addedStringRef);
@@ -98,7 +98,7 @@ void ConstantLoadInsn::translate(LLVMModuleRef &modRef) {
         LLVMValueRef valueRef = LLVMBuildInBoundsGEP(builder, wrap(globalStringValue.get()), paramTypes, 2, "simple");
         LLVMValueRef addedStringRef = getNewString(modRef);
 
-        LLVMValueRef sizeOpValueRef[] = {valueRef, LLVMConstInt(LLVMInt32Type(), stringValue.length(), false)};
+        LLVMValueRef sizeOpValueRef[] = {valueRef, LLVMConstInt(LLVMInt64Type(), stringValue.length(), false)};
         constRef = LLVMBuildCall(builder, addedStringRef, sizeOpValueRef, 2, "");
         break;
     }

--- a/compiler/codegen/Function.cpp
+++ b/compiler/codegen/Function.cpp
@@ -188,7 +188,7 @@ void Function::storeValueInSmartStruct(LLVMModuleRef &modRef, LLVMValueRef value
     std::string_view valueTypeName = Type::typeStringMangleName(valueType);
     parentPackage->addToStrTable(valueTypeName);
     int tempRandNum1 = std::rand() % 1000 + 1;
-    LLVMValueRef constValue = LLVMConstInt(LLVMInt32Type(), tempRandNum1, 0);
+    LLVMValueRef constValue = LLVMConstInt(LLVMInt64Type(), tempRandNum1, 0);
     LLVMValueRef valueTypeStoreRef = LLVMBuildStore(llvmBuilder, constValue, inherentTypeIdx);
     parentPackage->addStringOffsetRelocationEntry(valueTypeName.data(), valueTypeStoreRef);
 

--- a/compiler/codegen/MapInsns.cpp
+++ b/compiler/codegen/MapInsns.cpp
@@ -67,7 +67,7 @@ void MapLoadInsn::translate(LLVMModuleRef &modRef) {
     auto builder = funcObj.getLLVMBuilder();
     
     LLVMValueRef lhs = funcObj.getLLVMLocalOrGlobalVar(getLhsOperand());
-    LLVMValueRef outParam = LLVMBuildAlloca(builder, LLVMInt32Type(), "_out_param");
+    LLVMValueRef outParam = LLVMBuildAlloca(builder, LLVMInt64Type(), "_out_param");
     LLVMValueRef params[] = {funcObj.createTempVariable(rhsOp), funcObj.createTempVariable(keyOp), outParam};
     
     [[maybe_unused]] LLVMValueRef retVal = LLVMBuildCall(builder, getMapLoadDeclaration(modRef), params, 3, "");
@@ -88,7 +88,7 @@ LLVMValueRef MapLoadInsn::getMapLoadDeclaration(LLVMModuleRef &modRef) {
     }
     LLVMTypeRef funcRetType = LLVMInt8Type();
     LLVMTypeRef paramTypes[] = {LLVMPointerType(LLVMInt8Type(), 0), LLVMPointerType(LLVMInt8Type(), 0),
-                                LLVMPointerType(LLVMInt32Type(), 0)};
+                                LLVMPointerType(LLVMInt64Type(), 0)};
     LLVMTypeRef funcType = LLVMFunctionType(funcRetType, paramTypes, 3, 0);
     mapLoadFunc = LLVMAddFunction(modRef, funcName, funcType);
     getPackageMutableRef().addFunctionRef(funcName, mapLoadFunc);

--- a/compiler/codegen/Package.cpp
+++ b/compiler/codegen/Package.cpp
@@ -84,7 +84,7 @@ LLVMTypeRef Package::getLLVMTypeOfType(TypeTag typeTag) const {
     case TYPE_TAG_UNION:
         return wrap(boxType.get());
     default:
-        return LLVMInt32Type();
+        return LLVMInt64Type();
     }
 }
 
@@ -113,7 +113,7 @@ void Package::translate(LLVMModuleRef &modRef) {
 
     // creating struct smart pointer to store any type variables data.
     LLVMTypeRef structGen = LLVMStructCreateNamed(LLVMGetGlobalContext(), "struct.smtPtr");
-    LLVMTypeRef structElementTypes[] = {LLVMInt32Type(), LLVMPointerType(LLVMInt8Type(), 0)};
+    LLVMTypeRef structElementTypes[] = {LLVMInt64Type(), LLVMPointerType(LLVMInt8Type(), 0)};
     LLVMStructSetBody(structGen, structElementTypes, 2, 0);
     boxType = std::unique_ptr<llvm::StructType>(llvm::unwrap<llvm::StructType>(structGen));
 
@@ -212,7 +212,7 @@ void Package::applyStringOffsetRelocations(LLVMModuleRef &modRef) {
 
     for (const auto &element : structElementStoreInst) {
         size_t finalOrigOffset = strBuilder->getOffset(element.first);
-        LLVMValueRef tempVal = LLVMConstInt(LLVMInt32Type(), finalOrigOffset, 0);
+        LLVMValueRef tempVal = LLVMConstInt(LLVMInt64Type(), finalOrigOffset, 0);
         for (const auto &insn : element.second) {
             auto *GEPInst = llvm::dyn_cast<llvm::GetElementPtrInst>(llvm::unwrap(insn));
             LLVMValueRef constOperand = (GEPInst != nullptr) ? LLVMGetOperand(insn, 1) : LLVMGetOperand(insn, 0);

--- a/compiler/codegen/TypeCastInsn.cpp
+++ b/compiler/codegen/TypeCastInsn.cpp
@@ -69,7 +69,7 @@ void TypeCastInsn::translate(LLVMModuleRef &modRef) {
         std::string_view lhsTypeName = Type::typeStringMangleName(lhsType);
         getPackageMutableRef().addToStrTable(lhsTypeName);
         int tempRandNum = std::rand() % 1000 + 1;
-        LLVMValueRef constValue = LLVMConstInt(LLVMInt32Type(), tempRandNum, 0);
+        LLVMValueRef constValue = LLVMConstInt(LLVMInt64Type(), tempRandNum, 0);
         LLVMValueRef lhsGep = LLVMBuildInBoundsGEP(builder, strTblLoad, &constValue, 1, "");
         // call is_same_type rust function to check LHS and RHS type are same or not.
         LLVMValueRef addedIsSameTypeFunc = getIsSameTypeDeclaration(modRef, lhsGep, gepOfStr);

--- a/compiler/include/Package.h
+++ b/compiler/include/Package.h
@@ -55,7 +55,7 @@ class Package : public Translatable {
 
   public:
     Package() = default;
-    ~Package() = default;
+    virtual ~Package() = default;
     Package(const Package &) = delete;
     Package(Package &&obj) noexcept = delete;
     Package &operator=(const Package &obj) = delete;

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,23 +1,25 @@
-# Add Rust Runtime
-include(ExternalProject)
-set_directory_properties(PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/runtime)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CARGO_CMD cargo build --verbose)
+    set(TARGET_DIR "release")
+else ()
+    set(CARGO_CMD cargo build --release --verbose)
+    set(TARGET_DIR "release")
+endif ()
+
+# Flags to enable C++/Rust LTO
+set(RUST_FLAGS "-Clinker-plugin-lto" "-Clinker=clang-11" "-Clink-arg=-fuse-ld=lld-11")
 
 # Add cargo build instructions for Rust based runtime
-ExternalProject_Add(
-    BallerinaRT
-    DOWNLOAD_COMMAND ""
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND cargo build --release
-    BINARY_DIR "${CMAKE_SOURCE_DIR}/runtime"
-    INSTALL_COMMAND ""
-    LOG_BUILD ON
-    BUILD_ALWAYS TRUE)
+add_custom_target(libballerina_rt
+  COMMENT "Generate static runtime lib"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} RUSTFLAGS="${RUST_FLAGS}" ${CARGO_CMD})
 
 # Add seperate (optional) target to generate header file for runtime lib using cbindgen
 add_custom_target(runtime_header
   COMMENT "Generate C header file for runtime lib"
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/runtime"
   COMMAND cbindgen --config cbindgen.toml --crate BallerinaRT --output include/ballerina_rt.h
-  DEPENDS BallerinaRT)
+  DEPENDS libballerina_rt)
 
-add_dependencies(runtime_header BallerinaRT)
+add_dependencies(runtime_header libballerina_rt)

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [lib]
 name = "ballerina_rt"
-crate-type = ["cdylib"]
+crate-type = ["staticlib"]
 
 [dependencies]
 num = "0.3"

--- a/test/testRunScript.sh
+++ b/test/testRunScript.sh
@@ -21,8 +21,6 @@ else
   fi
 fi
 
-
-
 #Ignoring Ballerina compiler errors due to the use of undefined external functions for print routines
 #if [ -s ./err.log ]
 #then
@@ -39,7 +37,7 @@ then
   exit 1
 fi
 
-clang -O0 -o $filename.out $filename-bir-dump.ll -L../../../runtime/target/release/ -lballerina_rt 2>clang_err.log
+clang-11 --target=x86_64-unknown-linux-gnu -c -O3 -flto=thin -Wno-override-module -o $filename.o $filename-bir-dump.ll 2>clang_err.log
 
 if [ -s ./clang_err.log ]
 then
@@ -48,8 +46,14 @@ then
   exit 1
 fi
 
-export LD_LIBRARY_PATH=../../../runtime/target/release
+clang-11 -flto=thin -fuse-ld=lld-11 -L../../runtime/release/ -lballerina_rt -lpthread -ldl -o $filename.out -O3 $filename.o 2>lld_err.log
+if [ -s ./lld_err.log ]
+then
+  echo "Linker error/warning. Error msg: "
+  cat ./lld_err.log
+  exit 1
+fi
 
 ./$filename.out
 
-rm $filename-bir-dump.ll $filename.out
+rm $filename-bir-dump.ll $filename.out $filename.o


### PR DESCRIPTION
## Purpose

This PR enables Link Time Optimization (specifically ThinLTO) between the runtime lib and ballerina apps. The `clang` compiler and the `lld` linker must be used for the this to work (no `gcc` or `ld` support). The clang's LLVM and rustc's LLVM version must also match. I've tested successfully with clang 11.0.0 and rust 1.49.0. 

Other changes: 
* The runtime lib is now built as a static lib (not a dynamic lib)
* When using cmake to build the runtime, the cargo build output is now shown in the std output  

Resolves #209 
Resolves #154 
