### PR TITLE
Fix broken move semantic support in BIR classes

### DIFF
--- a/compiler/BIRReader.cpp
+++ b/compiler/BIRReader.cpp
@@ -49,6 +49,22 @@ bool BIRReader::isLittleEndian() {
     return (int)*c != 0;
 }
 
+template <typename T>
+T swapEndian(T u) {
+    static_assert(CHAR_BIT == 8);
+    union {
+        T u;
+        unsigned char u8[sizeof(T)];
+    } source, dest;
+
+    source.u = u;
+
+    for (size_t k = 0; k < sizeof(T); k++) {
+        dest.u8[k] = source.u8[sizeof(T) - k - 1];
+    }
+    return dest.u;
+}
+
 // Read 1 byte from the stream
 uint8_t BIRReader::readU1() {
     uint8_t value = 0;
@@ -66,90 +82,45 @@ uint8_t BIRReader::peekReadU1() {
 // Read 2 bytes from the stream
 int16_t BIRReader::readS2be() {
     int16_t value = 0;
-    int16_t result = 0;
     char *p = reinterpret_cast<char *>(&value);
     is.read(p, sizeof(value));
-    char tmp = 0;
-    if (isLittleEndian()) {
-        tmp = p[0];
-        p[0] = p[1];
-        p[1] = tmp;
+    if (!isLittleEndian()) {
+        return value;
     }
-    result = value;
-    return result;
+    return swapEndian<int16_t>(value);
 }
 
 // Read 4 bytes from the stream
 int32_t BIRReader::readS4be() {
-    uint32_t value = 0;
-    is.read(reinterpret_cast<char *>(&value), sizeof(value));
-    if (isLittleEndian()) {
-        uint32_t result = 0;
-        result |= (value & 0x000000FFU) << 24;
-        result |= (value & 0x0000FF00U) << 8;
-        result |= (value & 0x00FF0000U) >> 8;
-        result |= (value & 0xFF000000U) >> 24;
-        value = result;
+    int32_t value = 0;
+    char *p = reinterpret_cast<char *>(&value);
+    is.read(p, sizeof(value));
+    if (!isLittleEndian()) {
+        return value;
     }
-    return value;
+    return swapEndian<int32_t>(value);
 }
 
 // Read 8 bytes from the stream
 int64_t BIRReader::readS8be() {
     int64_t value = 0;
-    int64_t result = 0;
     char *p = reinterpret_cast<char *>(&value);
     is.read(p, sizeof(value));
-    if (isLittleEndian()) {
-        char tmp = 0;
-
-        tmp = p[0];
-        p[0] = p[7];
-        p[7] = tmp;
-
-        tmp = p[1];
-        p[1] = p[6];
-        p[6] = tmp;
-
-        tmp = p[2];
-        p[2] = p[5];
-        p[5] = tmp;
-
-        tmp = p[3];
-        p[3] = p[4];
-        p[4] = tmp;
+    if (!isLittleEndian()) {
+        return value;
     }
-    result = value;
-    return result;
+    return swapEndian<int64_t>(value);
 }
 
 // Read 8 bytes from the stream for float value
 double BIRReader::readS8bef() {
     double value = NAN;
-    double result = NAN;
     char *p = reinterpret_cast<char *>(&value);
     is.read(p, sizeof(value));
-    if (isLittleEndian()) {
-        char tmp = 0;
-
-        tmp = p[0];
-        p[0] = p[7];
-        p[7] = tmp;
-
-        tmp = p[1];
-        p[1] = p[6];
-        p[6] = tmp;
-
-        tmp = p[2];
-        p[2] = p[5];
-        p[5] = tmp;
-
-        tmp = p[3];
-        p[3] = p[4];
-        p[4] = tmp;
+    if (!isLittleEndian()) {
+        return value;
     }
-    result = value;
-    return result;
+    return swapEndian<double>(value);
 }
 
 // Search string from the constant pool based on index

--- a/compiler/BIRReader.cpp
+++ b/compiler/BIRReader.cpp
@@ -22,14 +22,7 @@
 #include <cstdlib>
 #include <queue>
 
-#ifdef unix
-#include <libgen.h>
-#else
-#define __attribute__(unused)
-#endif
-
-using namespace std;
-using namespace nballerina;
+namespace nballerina {
 
 // Instruction readers object declarations
 ReadCondBrInsn ReadCondBrInsn::readCondBrInsn;
@@ -258,7 +251,7 @@ InvocableType ConstantPoolSet::getInvocableType(int32_t index) {
 }
 
 // Read Global Variable and push it to BIRPackage
-void BIRReader::readGlobalVar(nballerina::Package &birPackage) {
+void BIRReader::readGlobalVar(Package &birPackage) {
     uint8_t kind = readU1();
 
     int32_t varDclNameCpIndex = readS4be();
@@ -274,7 +267,7 @@ void BIRReader::readGlobalVar(nballerina::Package &birPackage) {
     birPackage.globalVars.emplace_back(std::move(type), constantPool->getStringCp(varDclNameCpIndex), (VarKind)kind);
 }
 
-void BIRReader::readLocalVar(nballerina::Function &birFunction) {
+void BIRReader::readLocalVar(Function &birFunction) {
     uint8_t kind = readU1();
     int32_t typeCpIndex = readS4be();
     auto type = constantPool->getTypeCp(typeCpIndex, false);
@@ -326,14 +319,14 @@ MapConstruct BIRReader::readMapConstructor() {
 }
 
 // Read TYPEDESC Insn
-std::unique_ptr<TypeDescInsn> ReadTypeDescInsn::readNonTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<TypeDescInsn> ReadTypeDescInsn::readNonTerminatorInsn(BasicBlock &currentBB) {
     auto lhsOp = readerRef.readOperand();
     [[maybe_unused]] int32_t typeCpIndex = readerRef.readS4be();
     return std::make_unique<TypeDescInsn>(std::move(lhsOp), currentBB);
 }
 
 // Read STRUCTURE Insn
-std::unique_ptr<StructureInsn> ReadStructureInsn::readNonTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<StructureInsn> ReadStructureInsn::readNonTerminatorInsn(BasicBlock &currentBB) {
     auto rhsOp = readerRef.readOperand();
     [[maybe_unused]] auto lhsOp = readerRef.readOperand();
 
@@ -352,7 +345,7 @@ std::unique_ptr<StructureInsn> ReadStructureInsn::readNonTerminatorInsn(nballeri
 }
 
 // Read CONST_LOAD Insn
-std::unique_ptr<ConstantLoadInsn> ReadConstLoadInsn::readNonTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<ConstantLoadInsn> ReadConstLoadInsn::readNonTerminatorInsn(BasicBlock &currentBB) {
     [[maybe_unused]] int32_t typeCpIndex = readerRef.readS4be();
     auto lhsOp = readerRef.readOperand();
 
@@ -397,14 +390,14 @@ std::unique_ptr<ConstantLoadInsn> ReadConstLoadInsn::readNonTerminatorInsn(nball
 }
 
 // Read Unary Operand
-std::unique_ptr<UnaryOpInsn> ReadUnaryInsn::readNonTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<UnaryOpInsn> ReadUnaryInsn::readNonTerminatorInsn(BasicBlock &currentBB) {
     auto rhsOp = readerRef.readOperand();
     auto lhsOp = readerRef.readOperand();
     return std::make_unique<UnaryOpInsn>(std::move(lhsOp), currentBB, std::move(rhsOp));
 }
 
 // Read Binary Operand
-std::unique_ptr<BinaryOpInsn> ReadBinaryInsn::readNonTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<BinaryOpInsn> ReadBinaryInsn::readNonTerminatorInsn(BasicBlock &currentBB) {
     auto rhsOp1 = readerRef.readOperand();
     auto rhsOp2 = readerRef.readOperand();
     auto lhsOp = readerRef.readOperand();
@@ -412,7 +405,7 @@ std::unique_ptr<BinaryOpInsn> ReadBinaryInsn::readNonTerminatorInsn(nballerina::
 }
 
 // Read BRANCH Insn
-std::unique_ptr<ConditionBrInsn> ReadCondBrInsn::readTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<ConditionBrInsn> ReadCondBrInsn::readTerminatorInsn(BasicBlock &currentBB) {
     auto lhsOp = readerRef.readOperand();
     int32_t trueBbIdNameCpIndex = readerRef.readS4be();
     int32_t falseBbIdNameCpIndex = readerRef.readS4be();
@@ -423,7 +416,7 @@ std::unique_ptr<ConditionBrInsn> ReadCondBrInsn::readTerminatorInsn(nballerina::
 }
 
 // Read MOV Insn
-std::unique_ptr<MoveInsn> ReadMoveInsn::readNonTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<MoveInsn> ReadMoveInsn::readNonTerminatorInsn(BasicBlock &currentBB) {
     auto rhsOp = readerRef.readOperand();
     auto lhsOp = readerRef.readOperand();
 
@@ -431,11 +424,11 @@ std::unique_ptr<MoveInsn> ReadMoveInsn::readNonTerminatorInsn(nballerina::BasicB
 }
 
 // Read Function Call
-std::unique_ptr<FunctionCallInsn> ReadFuncCallInsn::readTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<FunctionCallInsn> ReadFuncCallInsn::readTerminatorInsn(BasicBlock &currentBB) {
     [[maybe_unused]] uint8_t isVirtual = readerRef.readU1();
     [[maybe_unused]] int32_t packageIndex = readerRef.readS4be();
     int32_t callNameCpIndex = readerRef.readS4be();
-    string funcName = readerRef.constantPool->getStringCp(callNameCpIndex);
+    std::string funcName = readerRef.constantPool->getStringCp(callNameCpIndex);
     int32_t argumentsCount = readerRef.readS4be();
 
     std::vector<Operand> fnArgs;
@@ -454,7 +447,7 @@ std::unique_ptr<FunctionCallInsn> ReadFuncCallInsn::readTerminatorInsn(nballerin
 }
 
 // Read TypeCast Insn
-std::unique_ptr<TypeCastInsn> ReadTypeCastInsn::readNonTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<TypeCastInsn> ReadTypeCastInsn::readNonTerminatorInsn(BasicBlock &currentBB) {
     auto lhsOp = readerRef.readOperand();
     auto rhsOperand = readerRef.readOperand();
 
@@ -466,7 +459,7 @@ std::unique_ptr<TypeCastInsn> ReadTypeCastInsn::readNonTerminatorInsn(nballerina
 }
 
 // Read Type Test Insn
-std::unique_ptr<TypeTestInsn> ReadTypeTestInsn::readNonTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<TypeTestInsn> ReadTypeTestInsn::readNonTerminatorInsn(BasicBlock &currentBB) {
     int32_t typeCpIndex = readerRef.readS4be();
     Type typeDecl = readerRef.constantPool->getTypeCp(typeCpIndex, false);
     auto lhsOp = readerRef.readOperand();
@@ -475,7 +468,7 @@ std::unique_ptr<TypeTestInsn> ReadTypeTestInsn::readNonTerminatorInsn(nballerina
 }
 
 // Read Array Insn
-std::unique_ptr<ArrayInsn> ReadArrayInsn::readNonTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<ArrayInsn> ReadArrayInsn::readNonTerminatorInsn(BasicBlock &currentBB) {
     int32_t typeCpIndex = readerRef.readS4be();
     Type typeDecl = readerRef.constantPool->getTypeCp(typeCpIndex, false);
     auto lhsOp = readerRef.readOperand();
@@ -490,7 +483,7 @@ std::unique_ptr<ArrayInsn> ReadArrayInsn::readNonTerminatorInsn(nballerina::Basi
 }
 
 // Read Array Store Insn
-std::unique_ptr<ArrayStoreInsn> ReadArrayStoreInsn::readNonTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<ArrayStoreInsn> ReadArrayStoreInsn::readNonTerminatorInsn(BasicBlock &currentBB) {
     auto lhsOp = readerRef.readOperand();
     auto keyOperand = readerRef.readOperand();
     auto rhsOperand = readerRef.readOperand();
@@ -498,7 +491,7 @@ std::unique_ptr<ArrayStoreInsn> ReadArrayStoreInsn::readNonTerminatorInsn(nballe
 }
 
 // Read Array Load Insn
-std::unique_ptr<ArrayLoadInsn> ReadArrayLoadInsn::readNonTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<ArrayLoadInsn> ReadArrayLoadInsn::readNonTerminatorInsn(BasicBlock &currentBB) {
     [[maybe_unused]] uint8_t optionalFieldAccess = readerRef.readU1();
     [[maybe_unused]] uint8_t fillingRead = readerRef.readU1();
     auto lhsOp = readerRef.readOperand();
@@ -508,7 +501,7 @@ std::unique_ptr<ArrayLoadInsn> ReadArrayLoadInsn::readNonTerminatorInsn(nballeri
 }
 
 // Read Map Store Insn
-std::unique_ptr<MapStoreInsn> ReadMapStoreInsn::readNonTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<MapStoreInsn> ReadMapStoreInsn::readNonTerminatorInsn(BasicBlock &currentBB) {
     auto lhsOp = readerRef.readOperand();
     auto keyOperand = readerRef.readOperand();
     auto rhsOperand = readerRef.readOperand();
@@ -516,7 +509,7 @@ std::unique_ptr<MapStoreInsn> ReadMapStoreInsn::readNonTerminatorInsn(nballerina
 }
 
 // Read Map Load Insn
-std::unique_ptr<MapLoadInsn> ReadMapLoadInsn::readNonTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<MapLoadInsn> ReadMapLoadInsn::readNonTerminatorInsn(BasicBlock &currentBB) {
     [[maybe_unused]] uint8_t optionalFieldAccess = readerRef.readU1();
     [[maybe_unused]] uint8_t fillingRead = readerRef.readU1();
     auto lhsOp = readerRef.readOperand();
@@ -525,17 +518,17 @@ std::unique_ptr<MapLoadInsn> ReadMapLoadInsn::readNonTerminatorInsn(nballerina::
     return std::make_unique<MapLoadInsn>(std::move(lhsOp), currentBB, std::move(keyOperand), std::move(rhsOperand));
 }
 
-std::unique_ptr<GoToInsn> ReadGoToInsn::readTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<GoToInsn> ReadGoToInsn::readTerminatorInsn(BasicBlock &currentBB) {
     auto nameId = readerRef.readS4be();
     return std::make_unique<GoToInsn>(currentBB, readerRef.constantPool->getStringCp(nameId));
 }
 
-std::unique_ptr<ReturnInsn> ReadReturnInsn::readTerminatorInsn(nballerina::BasicBlock &currentBB) {
+std::unique_ptr<ReturnInsn> ReadReturnInsn::readTerminatorInsn(BasicBlock &currentBB) {
     return std::make_unique<ReturnInsn>(currentBB);
 }
 
 // Read an Instruction - either a NonTerminatorInsn or TerminatorInsn from the BIR
-void BIRReader::readInsn(nballerina::BasicBlock &basicBlock) {
+void BIRReader::readInsn(BasicBlock &basicBlock) {
     int32_t sourceFileCpIndex = readS4be();
     int32_t sLine = readS4be();
     int32_t sCol = readS4be();
@@ -645,6 +638,7 @@ void BIRReader::readBasicBlock(Function &birFunction, bool ignore) {
     auto &basicBlock = birFunction.basicBlocks.back();
 
     int32_t insnCount = readS4be();
+    basicBlock.instructions.reserve(insnCount);
     for (auto i = 0; i < insnCount; i++) {
         readInsn(basicBlock);
     }
@@ -699,7 +693,7 @@ void BIRReader::readFunction(Package &package, bool ignore) {
     int32_t requiredParamCount = readS4be();
 
     // Set function param here and then fill remaining values from the default Params
-    std::queue<nballerina::Operand> functionParams;
+    std::queue<Operand> functionParams;
     for (auto i = 0; i < requiredParamCount; i++) {
         int32_t paramNameCpIndex = readS4be();
         functionParams.emplace(Operand(constantPool->getStringCp(paramNameCpIndex), ARG_VAR_KIND));
@@ -1199,7 +1193,7 @@ void BIRReader::patchTypesToFuncParam() {
 }
 */
 
-nballerina::Package BIRReader::readModule() {
+Package BIRReader::readModule() {
     int32_t idCpIndex = readS4be();
     ConstantPoolEntry *poolEntry = constantPool->getEntry(idCpIndex);
     auto birPackage = Package();
@@ -1288,7 +1282,7 @@ nballerina::Package BIRReader::readModule() {
     return birPackage;
 }
 
-nballerina::Package BIRReader::deserialize() {
+Package BIRReader::deserialize() {
     // Read Constant Pool
     auto *constantPoolSet = new ConstantPoolSet();
     constantPoolSet->read();
@@ -1360,3 +1354,5 @@ void RecordField::read() {
     doc->read();
     typeCpIndex = readerRef.readS4be();
 }
+
+} // namespace nballerina

--- a/compiler/BIRReader.h
+++ b/compiler/BIRReader.h
@@ -31,18 +31,18 @@
 #include "bir/InvocableType.h"
 #include "bir/MapInsns.h"
 #include "bir/MoveInsn.h"
-#include "interfaces/NonTerminatorInsn.h"
 #include "bir/Operand.h"
 #include "bir/Package.h"
 #include "bir/ReturnInsn.h"
 #include "bir/StructureInsn.h"
-#include "interfaces/TerminatorInsn.h"
 #include "bir/TypeCastInsn.h"
 #include "bir/TypeDescInsn.h"
 #include "bir/TypeTestInsn.h"
 #include "bir/Types.h"
 #include "bir/UnaryOpInsn.h"
 #include "bir/Variable.h"
+#include "interfaces/NonTerminatorInsn.h"
+#include "interfaces/TerminatorInsn.h"
 #include <fstream>
 
 class ConstantPoolSet;
@@ -65,10 +65,10 @@ class BIRReader {
     nballerina::MapConstruct readMapConstructor();
     nballerina::TypeDescInsn *readTypeDescInsn();
     nballerina::StructureInsn *readStructureInsn();
-    void readInsn(std::shared_ptr<nballerina::BasicBlock> basicBlock);
-    std::shared_ptr<nballerina::BasicBlock> readBasicBlock(std::shared_ptr<nballerina::Function> birFunction);
-    std::shared_ptr<nballerina::Function> readFunction(std::shared_ptr<nballerina::Package> birPackage);
-    std::shared_ptr<nballerina::Package> readModule();
+    void readInsn(nballerina::BasicBlock &basicBlock);
+    std::unique_ptr<nballerina::BasicBlock> readBasicBlock(nballerina::Function &birFunction);
+    std::unique_ptr<nballerina::Function> readFunction(nballerina::Package &birPackage);
+    nballerina::Package readModule();
 
     // Read bytes functions
     uint8_t readU1();
@@ -92,7 +92,7 @@ class BIRReader {
         is.open(fileName, std::ifstream::binary);
     }
     std::string getFileName() { return fileName; }
-    std::shared_ptr<nballerina::Package> deserialize();
+    nballerina::Package deserialize();
     void setConstantPool(ConstantPoolSet *constantPoolSet) { constantPool = constantPoolSet; }
     void patchTypesToFuncParam();
     friend class ConstantPoolEntry;
@@ -463,7 +463,7 @@ class ReadCondBrInsn : public ReadTerminatorInstruction {
     static ReadCondBrInsn readCondBrInsn;
     ReadCondBrInsn() {}
     ~ReadCondBrInsn() {}
-    std::unique_ptr<nballerina::ConditionBrInsn> readTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::ConditionBrInsn> readTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadFuncCallInsn : public ReadTerminatorInstruction {
@@ -471,7 +471,7 @@ class ReadFuncCallInsn : public ReadTerminatorInstruction {
     static ReadFuncCallInsn readFuncCallInsn;
     ReadFuncCallInsn() {}
     ~ReadFuncCallInsn() {}
-    std::unique_ptr<nballerina::FunctionCallInsn> readTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::FunctionCallInsn> readTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadGoToInsn : public ReadTerminatorInstruction {
@@ -479,7 +479,7 @@ class ReadGoToInsn : public ReadTerminatorInstruction {
     static ReadGoToInsn readGoToInsn;
     ReadGoToInsn() {}
     ~ReadGoToInsn() {}
-    std::unique_ptr<nballerina::GoToInsn> readTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::GoToInsn> readTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadReturnInsn : public ReadTerminatorInstruction {
@@ -487,7 +487,7 @@ class ReadReturnInsn : public ReadTerminatorInstruction {
     static ReadReturnInsn readReturnInsn;
     ReadReturnInsn() {}
     ~ReadReturnInsn() {}
-    std::unique_ptr<nballerina::ReturnInsn> readTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::ReturnInsn> readTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadBinaryInsn : public ReadNonTerminatorInstruction {
@@ -495,7 +495,7 @@ class ReadBinaryInsn : public ReadNonTerminatorInstruction {
     static ReadBinaryInsn readBinaryInsn;
     ReadBinaryInsn() {}
     ~ReadBinaryInsn() {}
-    std::unique_ptr<nballerina::BinaryOpInsn> readNonTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::BinaryOpInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadUnaryInsn : public ReadNonTerminatorInstruction {
@@ -503,7 +503,7 @@ class ReadUnaryInsn : public ReadNonTerminatorInstruction {
     static ReadUnaryInsn readUnaryInsn;
     ReadUnaryInsn() {}
     ~ReadUnaryInsn() {}
-    std::unique_ptr<nballerina::UnaryOpInsn> readNonTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::UnaryOpInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadConstLoadInsn : public ReadNonTerminatorInstruction {
@@ -511,8 +511,7 @@ class ReadConstLoadInsn : public ReadNonTerminatorInstruction {
     static ReadConstLoadInsn readConstLoadInsn;
     ReadConstLoadInsn() {}
     ~ReadConstLoadInsn() {}
-    std::unique_ptr<nballerina::ConstantLoadInsn>
-    readNonTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::ConstantLoadInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadMoveInsn : public ReadNonTerminatorInstruction {
@@ -520,7 +519,7 @@ class ReadMoveInsn : public ReadNonTerminatorInstruction {
     static ReadMoveInsn readMoveInsn;
     ReadMoveInsn() {}
     ~ReadMoveInsn() {}
-    std::unique_ptr<nballerina::MoveInsn> readNonTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::MoveInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadTypeDescInsn : public ReadNonTerminatorInstruction {
@@ -528,7 +527,7 @@ class ReadTypeDescInsn : public ReadNonTerminatorInstruction {
     static ReadTypeDescInsn readTypeDescInsn;
     ReadTypeDescInsn() {}
     ~ReadTypeDescInsn() {}
-    std::unique_ptr<nballerina::TypeDescInsn> readNonTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::TypeDescInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadStructureInsn : public ReadNonTerminatorInstruction {
@@ -536,7 +535,7 @@ class ReadStructureInsn : public ReadNonTerminatorInstruction {
     static ReadStructureInsn readStructureInsn;
     ReadStructureInsn() {}
     ~ReadStructureInsn() {}
-    std::unique_ptr<nballerina::StructureInsn> readNonTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::StructureInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadTypeCastInsn : public ReadNonTerminatorInstruction {
@@ -544,7 +543,7 @@ class ReadTypeCastInsn : public ReadNonTerminatorInstruction {
     static ReadTypeCastInsn readTypeCastInsn;
     ReadTypeCastInsn() {}
     ~ReadTypeCastInsn() {}
-    std::unique_ptr<nballerina::TypeCastInsn> readNonTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::TypeCastInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadTypeTestInsn : public ReadNonTerminatorInstruction {
@@ -552,7 +551,7 @@ class ReadTypeTestInsn : public ReadNonTerminatorInstruction {
     ReadTypeTestInsn() {}
     static ReadTypeTestInsn readTypeTestInsn;
     ~ReadTypeTestInsn() {}
-    std::unique_ptr<nballerina::TypeTestInsn> readNonTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::TypeTestInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadArrayInsn : public ReadNonTerminatorInstruction {
@@ -560,7 +559,7 @@ class ReadArrayInsn : public ReadNonTerminatorInstruction {
     ReadArrayInsn() {}
     static ReadArrayInsn readArrayInsn;
     ~ReadArrayInsn() {}
-    std::unique_ptr<nballerina::ArrayInsn> readNonTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::ArrayInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadArrayStoreInsn : public ReadNonTerminatorInstruction {
@@ -568,8 +567,7 @@ class ReadArrayStoreInsn : public ReadNonTerminatorInstruction {
     ReadArrayStoreInsn() {}
     static ReadArrayStoreInsn readArrayStoreInsn;
     ~ReadArrayStoreInsn() {}
-    std::unique_ptr<nballerina::ArrayStoreInsn>
-    readNonTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::ArrayStoreInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadArrayLoadInsn : public ReadNonTerminatorInstruction {
@@ -577,7 +575,7 @@ class ReadArrayLoadInsn : public ReadNonTerminatorInstruction {
     ReadArrayLoadInsn() {}
     static ReadArrayLoadInsn readArrayLoadInsn;
     ~ReadArrayLoadInsn() {}
-    std::unique_ptr<nballerina::ArrayLoadInsn> readNonTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::ArrayLoadInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadMapStoreInsn : public ReadNonTerminatorInstruction {
@@ -585,7 +583,7 @@ class ReadMapStoreInsn : public ReadNonTerminatorInstruction {
     ReadMapStoreInsn() {}
     static ReadMapStoreInsn readMapStoreInsn;
     ~ReadMapStoreInsn() {}
-    std::unique_ptr<nballerina::MapStoreInsn> readNonTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::MapStoreInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 class ReadMapLoadInsn : public ReadNonTerminatorInstruction {
@@ -593,7 +591,7 @@ class ReadMapLoadInsn : public ReadNonTerminatorInstruction {
     ReadMapLoadInsn() {}
     static ReadMapLoadInsn readMapLoadInsn;
     ~ReadMapLoadInsn() {}
-    std::unique_ptr<nballerina::MapLoadInsn> readNonTerminatorInsn(std::shared_ptr<nballerina::BasicBlock> currentBB);
+    std::unique_ptr<nballerina::MapLoadInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
 
 #endif // BIRREADER_H

--- a/compiler/BIRReader.h
+++ b/compiler/BIRReader.h
@@ -45,6 +45,8 @@
 #include "interfaces/TerminatorInsn.h"
 #include <fstream>
 
+namespace nballerina {
+
 class ConstantPoolSet;
 class ConstantPoolEntry;
 class PackageCpInfo;
@@ -59,15 +61,15 @@ class BIRReader {
     BIRReader() {}
 
     ConstantPoolSet *constantPool;
-    nballerina::Variable readGlobalVar();
+    void readGlobalVar(nballerina::Package &birPackage);
     nballerina::Operand readOperand();
-    nballerina::Variable readLocalVar();
+    void readLocalVar(nballerina::Function &birFunction);
     nballerina::MapConstruct readMapConstructor();
     nballerina::TypeDescInsn *readTypeDescInsn();
     nballerina::StructureInsn *readStructureInsn();
     void readInsn(nballerina::BasicBlock &basicBlock);
-    std::unique_ptr<nballerina::BasicBlock> readBasicBlock(nballerina::Function &birFunction);
-    std::unique_ptr<nballerina::Function> readFunction(nballerina::Package &birPackage);
+    void readBasicBlock(nballerina::Function &birFunction, bool ignore = false);
+    void readFunction(nballerina::Package &birPackage, bool ignore = false);
     nballerina::Package readModule();
 
     // Read bytes functions
@@ -593,5 +595,7 @@ class ReadMapLoadInsn : public ReadNonTerminatorInstruction {
     ~ReadMapLoadInsn() {}
     std::unique_ptr<nballerina::MapLoadInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
 };
+
+} // namespace nballerina
 
 #endif // BIRREADER_H

--- a/compiler/BIRReader.h
+++ b/compiler/BIRReader.h
@@ -44,6 +44,7 @@
 #include "interfaces/NonTerminatorInsn.h"
 #include "interfaces/TerminatorInsn.h"
 #include <fstream>
+#include <memory>
 
 namespace nballerina {
 
@@ -70,7 +71,7 @@ class BIRReader {
     void readInsn(BasicBlock &basicBlock);
     void readBasicBlock(Function &birFunction, bool ignore = false);
     void readFunction(Package &birPackage, bool ignore = false);
-    Package readModule();
+    std::shared_ptr<Package> readModule();
 
     // Read bytes functions
     uint8_t readU1();
@@ -94,7 +95,7 @@ class BIRReader {
         is.open(fileName, std::ifstream::binary);
     }
     std::string getFileName() { return fileName; }
-    Package deserialize();
+    std::shared_ptr<Package> deserialize();
     void setConstantPool(ConstantPoolSet *constantPoolSet) { constantPool = constantPoolSet; }
     void patchTypesToFuncParam();
     friend class ConstantPoolEntry;

--- a/compiler/BIRReader.h
+++ b/compiler/BIRReader.h
@@ -61,16 +61,16 @@ class BIRReader {
     BIRReader() {}
 
     ConstantPoolSet *constantPool;
-    void readGlobalVar(nballerina::Package &birPackage);
-    nballerina::Operand readOperand();
-    void readLocalVar(nballerina::Function &birFunction);
-    nballerina::MapConstruct readMapConstructor();
-    nballerina::TypeDescInsn *readTypeDescInsn();
-    nballerina::StructureInsn *readStructureInsn();
-    void readInsn(nballerina::BasicBlock &basicBlock);
-    void readBasicBlock(nballerina::Function &birFunction, bool ignore = false);
-    void readFunction(nballerina::Package &birPackage, bool ignore = false);
-    nballerina::Package readModule();
+    void readGlobalVar(Package &birPackage);
+    Operand readOperand();
+    void readLocalVar(Function &birFunction);
+    MapConstruct readMapConstructor();
+    TypeDescInsn *readTypeDescInsn();
+    StructureInsn *readStructureInsn();
+    void readInsn(BasicBlock &basicBlock);
+    void readBasicBlock(Function &birFunction, bool ignore = false);
+    void readFunction(Package &birPackage, bool ignore = false);
+    Package readModule();
 
     // Read bytes functions
     uint8_t readU1();
@@ -94,7 +94,7 @@ class BIRReader {
         is.open(fileName, std::ifstream::binary);
     }
     std::string getFileName() { return fileName; }
-    nballerina::Package deserialize();
+    Package deserialize();
     void setConstantPool(ConstantPoolSet *constantPoolSet) { constantPool = constantPoolSet; }
     void patchTypesToFuncParam();
     friend class ConstantPoolEntry;
@@ -291,7 +291,7 @@ class ShapeCpInfo : public ConstantPoolEntry {
   private:
     int32_t shapeLength;
     std::string value;
-    nballerina::TypeTag typeTag;
+    TypeTag typeTag;
     int32_t nameIndex;
     int32_t typeFlag;
     int32_t typeSpecialFlag;
@@ -308,7 +308,7 @@ class ShapeCpInfo : public ConstantPoolEntry {
   public:
     int32_t getShapeLength() { return shapeLength; }
     std::string getValue() { return value; }
-    nballerina::TypeTag getTypeTag() { return typeTag; }
+    TypeTag getTypeTag() { return typeTag; }
     int32_t getNameIndex() { return nameIndex; }
     int32_t getTypeFlag() { return typeFlag; }
     int32_t getTypeSpecialFlag() { return typeSpecialFlag; }
@@ -325,7 +325,7 @@ class ShapeCpInfo : public ConstantPoolEntry {
 
     void setShapeLength(int32_t s) { shapeLength = s; }
     void setValue(std::string v) { value = v; }
-    void setTypeTag(nballerina::TypeTag t) { typeTag = t; }
+    void setTypeTag(TypeTag t) { typeTag = t; }
     void setNameIndex(int32_t n) { nameIndex = n; }
     void setTypeFlag(int32_t t) { typeFlag = t; }
     void setTypeSpecialFlag(int32_t t) { typeSpecialFlag = t; }
@@ -434,11 +434,11 @@ class ConstantPoolSet {
     ConstantPoolEntry *getEntry(int index) { return poolEntries[index].get(); }
     std::string getStringCp(int32_t index);
     int64_t getIntCp(int32_t index);
-    nballerina::Type getTypeCp(int32_t index, bool voidToInt);
+    Type getTypeCp(int32_t index, bool voidToInt);
     double getFloatCp(int32_t index);
     bool getBooleanCp(int32_t index);
-    nballerina::TypeTag getTypeTag(int32_t index);
-    nballerina::InvocableType getInvocableType(int32_t index);
+    TypeTag getTypeTag(int32_t index);
+    InvocableType getInvocableType(int32_t index);
 };
 
 class ReadInsn {
@@ -465,7 +465,7 @@ class ReadCondBrInsn : public ReadTerminatorInstruction {
     static ReadCondBrInsn readCondBrInsn;
     ReadCondBrInsn() {}
     ~ReadCondBrInsn() {}
-    std::unique_ptr<nballerina::ConditionBrInsn> readTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<ConditionBrInsn> readTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadFuncCallInsn : public ReadTerminatorInstruction {
@@ -473,7 +473,7 @@ class ReadFuncCallInsn : public ReadTerminatorInstruction {
     static ReadFuncCallInsn readFuncCallInsn;
     ReadFuncCallInsn() {}
     ~ReadFuncCallInsn() {}
-    std::unique_ptr<nballerina::FunctionCallInsn> readTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<FunctionCallInsn> readTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadGoToInsn : public ReadTerminatorInstruction {
@@ -481,7 +481,7 @@ class ReadGoToInsn : public ReadTerminatorInstruction {
     static ReadGoToInsn readGoToInsn;
     ReadGoToInsn() {}
     ~ReadGoToInsn() {}
-    std::unique_ptr<nballerina::GoToInsn> readTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<GoToInsn> readTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadReturnInsn : public ReadTerminatorInstruction {
@@ -489,7 +489,7 @@ class ReadReturnInsn : public ReadTerminatorInstruction {
     static ReadReturnInsn readReturnInsn;
     ReadReturnInsn() {}
     ~ReadReturnInsn() {}
-    std::unique_ptr<nballerina::ReturnInsn> readTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<ReturnInsn> readTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadBinaryInsn : public ReadNonTerminatorInstruction {
@@ -497,7 +497,7 @@ class ReadBinaryInsn : public ReadNonTerminatorInstruction {
     static ReadBinaryInsn readBinaryInsn;
     ReadBinaryInsn() {}
     ~ReadBinaryInsn() {}
-    std::unique_ptr<nballerina::BinaryOpInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<BinaryOpInsn> readNonTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadUnaryInsn : public ReadNonTerminatorInstruction {
@@ -505,7 +505,7 @@ class ReadUnaryInsn : public ReadNonTerminatorInstruction {
     static ReadUnaryInsn readUnaryInsn;
     ReadUnaryInsn() {}
     ~ReadUnaryInsn() {}
-    std::unique_ptr<nballerina::UnaryOpInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<UnaryOpInsn> readNonTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadConstLoadInsn : public ReadNonTerminatorInstruction {
@@ -513,7 +513,7 @@ class ReadConstLoadInsn : public ReadNonTerminatorInstruction {
     static ReadConstLoadInsn readConstLoadInsn;
     ReadConstLoadInsn() {}
     ~ReadConstLoadInsn() {}
-    std::unique_ptr<nballerina::ConstantLoadInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<ConstantLoadInsn> readNonTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadMoveInsn : public ReadNonTerminatorInstruction {
@@ -521,7 +521,7 @@ class ReadMoveInsn : public ReadNonTerminatorInstruction {
     static ReadMoveInsn readMoveInsn;
     ReadMoveInsn() {}
     ~ReadMoveInsn() {}
-    std::unique_ptr<nballerina::MoveInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<MoveInsn> readNonTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadTypeDescInsn : public ReadNonTerminatorInstruction {
@@ -529,7 +529,7 @@ class ReadTypeDescInsn : public ReadNonTerminatorInstruction {
     static ReadTypeDescInsn readTypeDescInsn;
     ReadTypeDescInsn() {}
     ~ReadTypeDescInsn() {}
-    std::unique_ptr<nballerina::TypeDescInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<TypeDescInsn> readNonTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadStructureInsn : public ReadNonTerminatorInstruction {
@@ -537,7 +537,7 @@ class ReadStructureInsn : public ReadNonTerminatorInstruction {
     static ReadStructureInsn readStructureInsn;
     ReadStructureInsn() {}
     ~ReadStructureInsn() {}
-    std::unique_ptr<nballerina::StructureInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<StructureInsn> readNonTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadTypeCastInsn : public ReadNonTerminatorInstruction {
@@ -545,7 +545,7 @@ class ReadTypeCastInsn : public ReadNonTerminatorInstruction {
     static ReadTypeCastInsn readTypeCastInsn;
     ReadTypeCastInsn() {}
     ~ReadTypeCastInsn() {}
-    std::unique_ptr<nballerina::TypeCastInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<TypeCastInsn> readNonTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadTypeTestInsn : public ReadNonTerminatorInstruction {
@@ -553,7 +553,7 @@ class ReadTypeTestInsn : public ReadNonTerminatorInstruction {
     ReadTypeTestInsn() {}
     static ReadTypeTestInsn readTypeTestInsn;
     ~ReadTypeTestInsn() {}
-    std::unique_ptr<nballerina::TypeTestInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<TypeTestInsn> readNonTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadArrayInsn : public ReadNonTerminatorInstruction {
@@ -561,7 +561,7 @@ class ReadArrayInsn : public ReadNonTerminatorInstruction {
     ReadArrayInsn() {}
     static ReadArrayInsn readArrayInsn;
     ~ReadArrayInsn() {}
-    std::unique_ptr<nballerina::ArrayInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<ArrayInsn> readNonTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadArrayStoreInsn : public ReadNonTerminatorInstruction {
@@ -569,7 +569,7 @@ class ReadArrayStoreInsn : public ReadNonTerminatorInstruction {
     ReadArrayStoreInsn() {}
     static ReadArrayStoreInsn readArrayStoreInsn;
     ~ReadArrayStoreInsn() {}
-    std::unique_ptr<nballerina::ArrayStoreInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<ArrayStoreInsn> readNonTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadArrayLoadInsn : public ReadNonTerminatorInstruction {
@@ -577,7 +577,7 @@ class ReadArrayLoadInsn : public ReadNonTerminatorInstruction {
     ReadArrayLoadInsn() {}
     static ReadArrayLoadInsn readArrayLoadInsn;
     ~ReadArrayLoadInsn() {}
-    std::unique_ptr<nballerina::ArrayLoadInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<ArrayLoadInsn> readNonTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadMapStoreInsn : public ReadNonTerminatorInstruction {
@@ -585,7 +585,7 @@ class ReadMapStoreInsn : public ReadNonTerminatorInstruction {
     ReadMapStoreInsn() {}
     static ReadMapStoreInsn readMapStoreInsn;
     ~ReadMapStoreInsn() {}
-    std::unique_ptr<nballerina::MapStoreInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<MapStoreInsn> readNonTerminatorInsn(BasicBlock &currentBB);
 };
 
 class ReadMapLoadInsn : public ReadNonTerminatorInstruction {
@@ -593,7 +593,7 @@ class ReadMapLoadInsn : public ReadNonTerminatorInstruction {
     ReadMapLoadInsn() {}
     static ReadMapLoadInsn readMapLoadInsn;
     ~ReadMapLoadInsn() {}
-    std::unique_ptr<nballerina::MapLoadInsn> readNonTerminatorInsn(nballerina::BasicBlock &currentBB);
+    std::unique_ptr<MapLoadInsn> readNonTerminatorInsn(BasicBlock &currentBB);
 };
 
 } // namespace nballerina

--- a/compiler/BIRReader.h
+++ b/compiler/BIRReader.h
@@ -77,8 +77,8 @@ class BIRReader {
     int32_t readS4be();
     int64_t readS8be();
     double readS8bef();
-    bool isLittleEndian();
-    static bool ignoreFunction(std::string funcName);
+    static bool isLittleEndian();
+    static bool ignoreFunction(const std::string &funcName);
 
   public:
     static BIRReader reader;

--- a/compiler/bir/AbstractInstruction.cpp
+++ b/compiler/bir/AbstractInstruction.cpp
@@ -16,32 +16,15 @@
  * under the License.
  */
 
-#ifndef __LOCATION__H__
-#define __LOCATION__H__
-
-#include <string>
+#include "interfaces/AbstractInstruction.h"
+#include "bir/BasicBlock.h"
+#include "bir/Function.h"
 
 namespace nballerina {
 
-class Location {
-  private:
-    std::string fileName;
-    int sLine;
-    int sCol;
-    int eLine;
-    int eCol;
+AbstractInstruction::AbstractInstruction(Operand lOp, BasicBlock &parentBB)
+    : parentBB(parentBB), lhsOp(std::move(lOp)) {}
 
-  public:
-    Location() = default;
-    Location(std::string name, int sline, int scol, int eline, int ecol);
-
-    const std::string &getFileName() const;
-    int getStartLineNum() const;
-    int getStartColumnNum() const;
-    int getEndLineNum() const;
-    int getEndColumnNum() const;
-};
+const Function &AbstractInstruction::getFunctionRef() const { return parentBB.getParentFunctionRef(); }
 
 } // namespace nballerina
-
-#endif //!__LOCATION__H__

--- a/compiler/bir/BasicBlock.cpp
+++ b/compiler/bir/BasicBlock.cpp
@@ -18,23 +18,18 @@
 
 #include "bir/BasicBlock.h"
 #include "bir/Function.h"
-#include "interfaces/NonTerminatorInsn.h"
-#include "interfaces/TerminatorInsn.h"
 
 namespace nballerina {
 
-BasicBlock::BasicBlock(std::string pid, Function &parentFunc)
+BasicBlock::BasicBlock(std::string pid, Function *parentFunc)
     : id(std::move(pid)), parentFunction(parentFunc), terminator(nullptr) {}
 
 const std::string &BasicBlock::getId() const { return id; }
 TerminatorInsn *BasicBlock::getTerminatorInsnPtr() const { return terminator.get(); }
 
-Function &BasicBlock::getFunctionMutableRef() const { return parentFunction; }
-
-const Function &BasicBlock::getParentFunctionRef() const { return parentFunction; }
+const Function &BasicBlock::getParentFunctionRef() const { return *parentFunction; }
 
 void BasicBlock::setTerminatorInsn(std::unique_ptr<TerminatorInsn> insn) { terminator = std::move(insn); }
-void BasicBlock::setNextBB(std::weak_ptr<BasicBlock> bb) { nextBB = std::move(bb); }
 void BasicBlock::addNonTermInsn(std::unique_ptr<NonTerminatorInsn> insn) { instructions.push_back(std::move(insn)); }
 
 } // namespace nballerina

--- a/compiler/bir/Function.cpp
+++ b/compiler/bir/Function.cpp
@@ -19,6 +19,7 @@
 #include "bir/Function.h"
 #include "bir/Package.h"
 #include "bir/Types.h"
+#include <algorithm>
 #include <cassert>
 
 namespace nballerina {
@@ -31,13 +32,6 @@ const std::vector<FunctionParam> &Function::getParams() const { return requiredP
 const std::optional<RestParam> &Function::getRestParam() const { return restParam; }
 const std::optional<Variable> &Function::getReturnVar() const { return returnVar; }
 
-void Function::insertParam(FunctionParam param) { requiredParams.push_back(std::move(param)); }
-void Function::insertLocalVar(Variable var) {
-    localVars.insert(std::pair<std::string, Variable>(var.getName(), std::move(var)));
-}
-void Function::setReturnVar(Variable var) { returnVar = std::move(var); }
-void Function::insertBasicBlock(std::unique_ptr<BasicBlock> bb) { basicBlocks.push_back(std::move(bb)); }
-
 const Variable &Function::getLocalOrGlobalVariable(const Operand &op) const {
     if (op.getKind() == GLOBAL_VAR_KIND) {
         return parentPackage->getGlobalVariable(op.getName());
@@ -46,9 +40,10 @@ const Variable &Function::getLocalOrGlobalVariable(const Operand &op) const {
 }
 
 const Variable &Function::getLocalVariable(const std::string &opName) const {
-    const auto &varIt = localVars.find(opName);
-    assert(varIt != localVars.end());
-    return varIt->second;
+    auto result = std::find_if(localVars.begin(), localVars.end(),
+                               [&opName](const Variable &i) -> bool { return i.getName() == opName; });
+    assert(result != localVars.end());
+    return *result;
 }
 
 size_t Function::getNumParams() const { return requiredParams.size(); }

--- a/compiler/bir/Function.cpp
+++ b/compiler/bir/Function.cpp
@@ -17,16 +17,13 @@
  */
 
 #include "bir/Function.h"
-#include "bir/BasicBlock.h"
-#include "bir/FunctionParam.h"
-#include "bir/Operand.h"
 #include "bir/Package.h"
 #include "bir/Types.h"
 #include <cassert>
 
 namespace nballerina {
 
-Function::Function(Package &parentPackage, std::string name, std::string workerName, unsigned int flags)
+Function::Function(Package *parentPackage, std::string name, std::string workerName, unsigned int flags)
     : parentPackage(parentPackage), name(std::move(name)), workerName(std::move(workerName)), flags(flags) {}
 
 const std::string &Function::getName() const { return name; }
@@ -34,16 +31,16 @@ const std::vector<FunctionParam> &Function::getParams() const { return requiredP
 const std::optional<RestParam> &Function::getRestParam() const { return restParam; }
 const std::optional<Variable> &Function::getReturnVar() const { return returnVar; }
 
-void Function::insertParam(const FunctionParam &param) { requiredParams.push_back(param); }
-void Function::insertLocalVar(const Variable &var) {
-    localVars.insert(std::pair<std::string, Variable>(var.getName(), var));
+void Function::insertParam(FunctionParam param) { requiredParams.push_back(std::move(param)); }
+void Function::insertLocalVar(Variable var) {
+    localVars.insert(std::pair<std::string, Variable>(var.getName(), std::move(var)));
 }
-void Function::setReturnVar(const Variable &var) { returnVar = var; }
-void Function::insertBasicBlock(const std::shared_ptr<BasicBlock> &bb) { basicBlocks.push_back(bb); }
+void Function::setReturnVar(Variable var) { returnVar = std::move(var); }
+void Function::insertBasicBlock(std::unique_ptr<BasicBlock> bb) { basicBlocks.push_back(std::move(bb)); }
 
 const Variable &Function::getLocalOrGlobalVariable(const Operand &op) const {
     if (op.getKind() == GLOBAL_VAR_KIND) {
-        return parentPackage.getGlobalVariable(op.getName());
+        return parentPackage->getGlobalVariable(op.getName());
     }
     return getLocalVariable(op.getName());
 }

--- a/compiler/bir/InvocableType.cpp
+++ b/compiler/bir/InvocableType.cpp
@@ -20,10 +20,10 @@
 
 namespace nballerina {
 
-InvocableType::InvocableType(std::vector<Type> paramTy, const Type &restTy, const Type &retTy)
-    : paramTypes(std::move(paramTy)), returnType(retTy), restType(restTy) {}
+InvocableType::InvocableType(std::vector<Type> paramTy, Type restTy, Type retTy)
+    : paramTypes(std::move(paramTy)), returnType(std::move(retTy)), restType(std::move(restTy)) {}
 
-InvocableType::InvocableType(std::vector<Type> paramTy, const Type &retTy)
-    : paramTypes(std::move(paramTy)), returnType(retTy) {}
+InvocableType::InvocableType(std::vector<Type> paramTy, Type retTy)
+    : paramTypes(std::move(paramTy)), returnType(std::move(retTy)) {}
 
 } // namespace nballerina

--- a/compiler/bir/Package.cpp
+++ b/compiler/bir/Package.cpp
@@ -17,34 +17,25 @@
  */
 
 #include "bir/Package.h"
+#include <algorithm>
 #include <cassert>
 
 namespace nballerina {
 
 std::string Package::getModuleName() const { return org + name + version; }
 
-void Package::setOrgName(std::string orgName) { org = std::move(orgName); }
-
-void Package::setPackageName(std::string pkgName) { name = std::move(pkgName); }
-
-void Package::setVersion(std::string verName) { version = std::move(verName); }
-
-void Package::setSrcFileName(std::string srcFileName) { sourceFileName = std::move(srcFileName); }
-
-void Package::insertFunction(std::unique_ptr<Function> function) {
-    functionLookUp.insert(std::pair<std::string, std::unique_ptr<Function>>(function->getName(), std::move(function)));
+const Function &Package::getFunction(const std::string &name) const {
+    auto result = std::find_if(functions.begin(), functions.end(),
+                               [&name](const Function &i) -> bool { return i.getName() == name; });
+    assert(result != functions.end());
+    return *result;
 }
-
-const Function &Package::getFunction(const std::string &name) const { return *functionLookUp.at(name); }
 
 const Variable &Package::getGlobalVariable(const std::string &name) const {
-    const auto &varIt = globalVars.find(name);
-    assert(varIt != globalVars.end());
-    return varIt->second;
-}
-
-void Package::insertGlobalVar(Variable var) {
-    globalVars.insert(std::pair<std::string, Variable>(var.getName(), std::move(var)));
+    auto result = std::find_if(globalVars.begin(), globalVars.end(),
+                               [&name](const Variable &i) -> bool { return i.getName() == name; });
+    assert(result != globalVars.end());
+    return *result;
 }
 
 } // namespace nballerina

--- a/compiler/bir/Package.cpp
+++ b/compiler/bir/Package.cpp
@@ -31,8 +31,8 @@ void Package::setVersion(std::string verName) { version = std::move(verName); }
 
 void Package::setSrcFileName(std::string srcFileName) { sourceFileName = std::move(srcFileName); }
 
-void Package::insertFunction(const std::shared_ptr<Function> &function) {
-    functionLookUp.insert(std::pair<std::string, std::shared_ptr<Function>>(function->getName(), function));
+void Package::insertFunction(std::unique_ptr<Function> function) {
+    functionLookUp.insert(std::pair<std::string, std::unique_ptr<Function>>(function->getName(), std::move(function)));
 }
 
 const Function &Package::getFunction(const std::string &name) const { return *functionLookUp.at(name); }
@@ -43,8 +43,8 @@ const Variable &Package::getGlobalVariable(const std::string &name) const {
     return varIt->second;
 }
 
-void Package::insertGlobalVar(const Variable &var) {
-    globalVars.insert(std::pair<std::string, Variable>(var.getName(), var));
+void Package::insertGlobalVar(Variable var) {
+    globalVars.insert(std::pair<std::string, Variable>(var.getName(), std::move(var)));
 }
 
 } // namespace nballerina

--- a/compiler/codegen/FunctionCodeGen.cpp
+++ b/compiler/codegen/FunctionCodeGen.cpp
@@ -70,8 +70,7 @@ void FunctionCodeGen::visit(Function &obj, llvm::IRBuilder<> &builder) {
 
     // iterate through all local vars.
     size_t paramIndex = 0;
-    for (auto const &it : obj.localVars) {
-        const auto &locVar = it.second;
+    for (auto const &locVar : obj.localVars) {
         auto *varType = CodeGenUtils::getLLVMTypeOfType(locVar.getType(), module);
         auto *localVarRef = builder.CreateAlloca(varType, nullptr, locVar.getName());
         localVarRefs.insert({locVar.getName(), localVarRef});
@@ -87,19 +86,19 @@ void FunctionCodeGen::visit(Function &obj, llvm::IRBuilder<> &builder) {
 
     // iterate through with each basic block in the function and create them
     for (auto &bb : obj.basicBlocks) {
-        basicBlocksMap[bb->getId()] = llvm::BasicBlock::Create(module.getContext(), bb->getId(), llvmFunction);
+        basicBlocksMap[bb.getId()] = llvm::BasicBlock::Create(module.getContext(), bb.getId(), llvmFunction);
     }
 
     // creating branch to next basic block.
     if (!obj.basicBlocks.empty()) {
-        builder.CreateBr(basicBlocksMap[obj.basicBlocks[0]->getId()]);
+        builder.CreateBr(basicBlocksMap[obj.basicBlocks[0].getId()]);
     }
 
     // Now translate the basic blocks (essentially add the instructions in them)
     for (auto &bb : obj.basicBlocks) {
-        builder.SetInsertPoint(basicBlocksMap[bb->getId()]);
+        builder.SetInsertPoint(basicBlocksMap[bb.getId()]);
         BasicBlockCodeGen generator(*this, parentGenerator);
-        generator.visit(*bb, builder);
+        generator.visit(bb, builder);
     }
 }
 } // namespace nballerina

--- a/compiler/codegen/FunctionCodeGen.cpp
+++ b/compiler/codegen/FunctionCodeGen.cpp
@@ -25,7 +25,8 @@
 
 namespace nballerina {
 
-FunctionCodeGen::FunctionCodeGen(PackageCodeGen &parentGenerator) : parentGenerator(parentGenerator) {}
+FunctionCodeGen::FunctionCodeGen(PackageCodeGen &parentGenerator)
+    : parentGenerator(parentGenerator), llvmFunction(nullptr) {}
 
 llvm::BasicBlock *FunctionCodeGen::getBasicBlock(const std::string &id) { return basicBlocksMap[id]; }
 

--- a/compiler/codegen/PackageCodeGen.cpp
+++ b/compiler/codegen/PackageCodeGen.cpp
@@ -46,8 +46,7 @@ void PackageCodeGen::visit(Package &obj, llvm::IRBuilder<> &builder) {
     globalStrTable->setAlignment(llvm::Align(4));
 
     // iterate over all global variables and translate
-    for (auto const &it : obj.globalVars) {
-        auto const &globVar = it.second;
+    for (auto const &globVar : obj.globalVars) {
         auto *varTyperef = CodeGenUtils::getLLVMTypeOfType(globVar.getType(), module);
         llvm::Constant *initValue = llvm::Constant::getNullValue(varTyperef);
         auto *gVar = new llvm::GlobalVariable(module, varTyperef, false, llvm::GlobalValue::ExternalLinkage, initValue,
@@ -57,28 +56,28 @@ void PackageCodeGen::visit(Package &obj, llvm::IRBuilder<> &builder) {
 
     // iterating over each function, first create function definition
     // (without function body) and adding to Module.
-    for (const auto &function : obj.functionLookUp) {
-        auto numParams = function.second->getNumParams();
+    for (const auto &function : obj.functions) {
+        auto numParams = function.getNumParams();
         std::vector<llvm::Type *> paramTypes;
         paramTypes.reserve(numParams);
-        for (const auto &funcParam : function.second->getParams()) {
+        for (const auto &funcParam : function.getParams()) {
             paramTypes.push_back(CodeGenUtils::getLLVMTypeOfType(funcParam.getType(), module));
         }
 
-        bool isVarArg = static_cast<bool>(function.second->getRestParam());
+        bool isVarArg = static_cast<bool>(function.getRestParam());
         auto *funcType =
-            llvm::FunctionType::get(FunctionCodeGen::getRetValType(*function.second, module), paramTypes, isVarArg);
+            llvm::FunctionType::get(FunctionCodeGen::getRetValType(function, module), paramTypes, isVarArg);
 
-        llvm::Function::Create(funcType, llvm::GlobalValue::ExternalLinkage, function.second->getName(), module);
+        llvm::Function::Create(funcType, llvm::GlobalValue::ExternalLinkage, function.getName(), module);
     }
 
     // iterating over each function translate the function body
-    for (auto &function : obj.functionLookUp) {
-        if (function.second->isExternalFunction()) {
+    for (auto &function : obj.functions) {
+        if (function.isExternalFunction()) {
             continue;
         }
         FunctionCodeGen funcGenerator(*this);
-        funcGenerator.visit(*function.second, builder);
+        funcGenerator.visit(function, builder);
     }
 
     // This Api will finalize the string table builder if table size is not zero

--- a/compiler/codegen/TerminatorInsnCodeGen.cpp
+++ b/compiler/codegen/TerminatorInsnCodeGen.cpp
@@ -32,9 +32,9 @@ TerminatorInsnCodeGen::TerminatorInsnCodeGen(FunctionCodeGen &functionGenerator,
 void TerminatorInsnCodeGen::visit(ConditionBrInsn &obj, llvm::IRBuilder<> &builder) {
     auto *lhsTemp = functionGenerator.createTempVal(obj.lhsOp, builder);
     auto *brCondition = builder.CreateIsNotNull(lhsTemp, obj.lhsOp.getName());
-    assert(functionGenerator.getBasicBlock(obj.getNextBBID()) != nullptr);
+    assert(functionGenerator.getBasicBlock(obj.thenBBID) != nullptr);
     assert(functionGenerator.getBasicBlock(obj.getElseBBID()) != nullptr);
-    builder.CreateCondBr(brCondition, functionGenerator.getBasicBlock(obj.getNextBBID()),
+    builder.CreateCondBr(brCondition, functionGenerator.getBasicBlock(obj.thenBBID),
                          functionGenerator.getBasicBlock(obj.getElseBBID()));
 }
 
@@ -51,15 +51,15 @@ void TerminatorInsnCodeGen::visit(FunctionCallInsn &obj, llvm::IRBuilder<> &buil
     builder.CreateStore(callResult, lhsRef);
 
     // creating branch to next basic block.
-    auto *nextBB = functionGenerator.getBasicBlock(obj.getNextBBID());
+    auto *nextBB = functionGenerator.getBasicBlock(obj.thenBBID);
     if (nextBB != nullptr) {
         builder.CreateBr(nextBB);
     }
 }
 
 void TerminatorInsnCodeGen::visit(GoToInsn &obj, llvm::IRBuilder<> &builder) {
-    assert(functionGenerator.getBasicBlock(obj.getNextBBID()) != nullptr);
-    builder.CreateBr(functionGenerator.getBasicBlock(obj.getNextBBID()));
+    assert(functionGenerator.getBasicBlock(obj.thenBBID) != nullptr);
+    builder.CreateBr(functionGenerator.getBasicBlock(obj.thenBBID));
 }
 
 void TerminatorInsnCodeGen::visit(ReturnInsn &obj, llvm::IRBuilder<> &builder) {

--- a/compiler/driver.cpp
+++ b/compiler/driver.cpp
@@ -64,8 +64,6 @@ int main(int argc, char **argv) {
 
     auto birPackage = nballerina::BIRReader::reader.deserialize();
 
-    printf("%p\n", &birPackage);
-
     // Codegen
-    return nballerina::CodeGenerator::generateLLVMIR(birPackage, outFileName);
+    return nballerina::CodeGenerator::generateLLVMIR(*birPackage, outFileName);
 }

--- a/compiler/driver.cpp
+++ b/compiler/driver.cpp
@@ -65,5 +65,5 @@ int main(int argc, char **argv) {
     auto birPackage = BIRReader::reader.deserialize();
 
     // Codegen
-    return nballerina::CodeGenerator::generateLLVMIR(*birPackage, outFileName);
+    return nballerina::CodeGenerator::generateLLVMIR(birPackage, outFileName);
 }

--- a/compiler/driver.cpp
+++ b/compiler/driver.cpp
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <string>
 
-BIRReader BIRReader::reader;
+nballerina::BIRReader nballerina::BIRReader::reader;
 
 std::string removeExtension(const std::string &path) {
     size_t pos = path.find_last_of("\\/.");
@@ -60,9 +60,11 @@ int main(int argc, char **argv) {
         outFileName = outFileName + ".ll";
     }
 
-    BIRReader::reader.setFileStream(inFileName);
+    nballerina::BIRReader::reader.setFileStream(inFileName);
 
-    auto birPackage = BIRReader::reader.deserialize();
+    auto birPackage = nballerina::BIRReader::reader.deserialize();
+
+    printf("%p\n", &birPackage);
 
     // Codegen
     return nballerina::CodeGenerator::generateLLVMIR(birPackage, outFileName);

--- a/compiler/include/bir/ArrayInstructions.h
+++ b/compiler/include/bir/ArrayInstructions.h
@@ -19,8 +19,8 @@
 #ifndef __ARRAYINSNS__H__
 #define __ARRAYINSNS__H__
 
-#include "interfaces/NonTerminatorInsn.h"
 #include "bir/Types.h"
+#include "interfaces/NonTerminatorInsn.h"
 
 namespace nballerina {
 
@@ -29,10 +29,8 @@ class ArrayInsn : public NonTerminatorInsn, public Translatable<ArrayInsn> {
     Operand sizeOp;
 
   public:
-    ArrayInsn() = delete;
-    ArrayInsn(const Operand &lhs, BasicBlock &currentBB, const Operand &sizeOp)
-        : NonTerminatorInsn(lhs, currentBB), sizeOp(sizeOp) {}
-    ~ArrayInsn() = default;
+    ArrayInsn(Operand lhs, BasicBlock &currentBB, Operand sizeOp)
+        : NonTerminatorInsn(std::move(lhs), currentBB), sizeOp(std::move(sizeOp)) {}
     friend class NonTerminatorInsnCodeGen;
 };
 
@@ -42,10 +40,8 @@ class ArrayLoadInsn : public NonTerminatorInsn, public Translatable<ArrayLoadIns
     Operand rhsOp;
 
   public:
-    ArrayLoadInsn() = delete;
-    ArrayLoadInsn(const Operand &lhs, BasicBlock &currentBB, const Operand &KOp, const Operand &ROp)
-        : NonTerminatorInsn(lhs, currentBB), keyOp(KOp), rhsOp(ROp) {}
-    ~ArrayLoadInsn() = default;
+    ArrayLoadInsn(Operand lhs, BasicBlock &currentBB, Operand KOp, Operand ROp)
+        : NonTerminatorInsn(std::move(lhs), currentBB), keyOp(std::move(KOp)), rhsOp(std::move(ROp)) {}
     friend class NonTerminatorInsnCodeGen;
 };
 
@@ -55,10 +51,8 @@ class ArrayStoreInsn : public NonTerminatorInsn, public Translatable<ArrayStoreI
     Operand rhsOp;
 
   public:
-    ArrayStoreInsn() = delete;
-    ArrayStoreInsn(const Operand &lhs, BasicBlock &currentBB, const Operand &KOp, const Operand &ROp)
-        : NonTerminatorInsn(lhs, currentBB), keyOp(KOp), rhsOp(ROp) {}
-    ~ArrayStoreInsn() = default;
+    ArrayStoreInsn(Operand lhs, BasicBlock &currentBB, Operand KOp, Operand ROp)
+        : NonTerminatorInsn(std::move(lhs), currentBB), keyOp(std::move(KOp)), rhsOp(std::move(ROp)) {}
     friend class NonTerminatorInsnCodeGen;
 };
 

--- a/compiler/include/bir/BasicBlock.h
+++ b/compiler/include/bir/BasicBlock.h
@@ -20,6 +20,8 @@
 #define __BASICBLOCK__H__
 
 #include "interfaces/Debuggable.h"
+#include "interfaces/NonTerminatorInsn.h"
+#include "interfaces/TerminatorInsn.h"
 #include <memory>
 #include <string>
 #include <vector>
@@ -27,32 +29,25 @@
 namespace nballerina {
 
 class Function;
-class TerminatorInsn;
-class NonTerminatorInsn;
 
 class BasicBlock : public Debuggable {
   private:
     std::string id;
-    Function &parentFunction;
+    Function *parentFunction;
     std::unique_ptr<TerminatorInsn> terminator;
-    std::weak_ptr<BasicBlock> nextBB;
     std::vector<std::unique_ptr<NonTerminatorInsn>> instructions;
 
   public:
-    BasicBlock() = delete;
-    BasicBlock(std::string id, Function &parentFunc);
+    BasicBlock(std::string id, Function *parentFunc);
     BasicBlock(const BasicBlock &) = delete;
-    BasicBlock(BasicBlock &&obj) noexcept = delete;
-    BasicBlock &operator=(const BasicBlock &obj) = delete;
-    BasicBlock &operator=(BasicBlock &&obj) noexcept = delete;
-    ~BasicBlock() = default;
+    BasicBlock(BasicBlock &&j) noexcept = default;
+    BasicBlock &operator=(const BasicBlock &) = delete;
+    BasicBlock &operator=(BasicBlock &&) noexcept = default;
 
     const std::string &getId() const;
     TerminatorInsn *getTerminatorInsnPtr() const;
-    Function &getFunctionMutableRef() const;
     const Function &getParentFunctionRef() const;
 
-    void setNextBB(std::weak_ptr<BasicBlock> bb);
     void setTerminatorInsn(std::unique_ptr<TerminatorInsn> insn);
     void addNonTermInsn(std::unique_ptr<NonTerminatorInsn> insn);
 

--- a/compiler/include/bir/BasicBlock.h
+++ b/compiler/include/bir/BasicBlock.h
@@ -52,6 +52,7 @@ class BasicBlock : public Debuggable {
     void addNonTermInsn(std::unique_ptr<NonTerminatorInsn> insn);
 
     friend class BasicBlockCodeGen;
+    friend class BIRReader;
 };
 
 } // namespace nballerina

--- a/compiler/include/bir/BinaryOpInsn.h
+++ b/compiler/include/bir/BinaryOpInsn.h
@@ -32,10 +32,8 @@ class BinaryOpInsn : public NonTerminatorInsn, public Translatable<BinaryOpInsn>
     InstructionKind kind;
 
   public:
-    BinaryOpInsn() = delete;
-    BinaryOpInsn(const Operand &lhs, class BasicBlock &currentBB, const Operand &rhsOp1, const Operand &rhsOp2)
-        : NonTerminatorInsn(lhs, currentBB), rhsOp1(rhsOp1), rhsOp2(rhsOp2), kind{} {}
-    ~BinaryOpInsn() = default;
+    BinaryOpInsn(Operand lhs, class BasicBlock &currentBB, Operand rhsOp1, Operand rhsOp2)
+        : NonTerminatorInsn(std::move(lhs), currentBB), rhsOp1(std::move(rhsOp1)), rhsOp2(std::move(rhsOp2)), kind{} {}
     void setInstKind(InstructionKind kind) { this->kind = kind; }
     friend class NonTerminatorInsnCodeGen;
 };

--- a/compiler/include/bir/ConditionBrInsn.h
+++ b/compiler/include/bir/ConditionBrInsn.h
@@ -29,12 +29,10 @@ class ConditionBrInsn : public TerminatorInsn, public Translatable<ConditionBrIn
     std::string elseBBID;
 
   public:
-    ConditionBrInsn() = delete;
-    ConditionBrInsn(const Operand &lhs, BasicBlock &currentBB, std::string ifBBID, std::string elseBBID)
-        : TerminatorInsn(lhs, currentBB, ifBBID), elseBBID(std::move(elseBBID)) {
+    ConditionBrInsn(Operand lhs, BasicBlock &currentBB, std::string ifBBID, std::string elseBBID)
+        : TerminatorInsn(std::move(lhs), currentBB, ifBBID), elseBBID(std::move(elseBBID)) {
         kind = INSTRUCTION_KIND_CONDITIONAL_BRANCH;
     }
-    ~ConditionBrInsn() = default;
 
     const std::string &getElseBBID() const { return elseBBID; }
     friend class TerminatorInsnCodeGen;

--- a/compiler/include/bir/ConstantLoad.h
+++ b/compiler/include/bir/ConstantLoad.h
@@ -32,18 +32,16 @@ class ConstantLoadInsn : public NonTerminatorInsn, public Translatable<ConstantL
     std::variant<int64_t, double, bool, std::string> value;
 
   public:
-    ConstantLoadInsn() = delete;
-    ConstantLoadInsn(const Operand &lhs, BasicBlock &currentBB, int64_t intVal)
-        : NonTerminatorInsn(lhs, currentBB), typeTag(TYPE_TAG_INT), value(intVal) {}
-    ConstantLoadInsn(const Operand &lhs, BasicBlock &currentBB, double doubleVal)
-        : NonTerminatorInsn(lhs, currentBB), typeTag(TYPE_TAG_FLOAT), value(doubleVal) {}
-    ConstantLoadInsn(const Operand &lhs, BasicBlock &currentBB, bool boolVal)
-        : NonTerminatorInsn(lhs, currentBB), typeTag(TYPE_TAG_BOOLEAN), value(boolVal) {}
-    ConstantLoadInsn(const Operand &lhs, BasicBlock &currentBB, std::string str)
-        : NonTerminatorInsn(lhs, currentBB), typeTag(TYPE_TAG_STRING), value(std::move(str)) {}
-    ConstantLoadInsn(const Operand &lhs, BasicBlock &currentBB)
-        : NonTerminatorInsn(lhs, currentBB), typeTag(TYPE_TAG_NIL) {}
-    ~ConstantLoadInsn() = default;
+    ConstantLoadInsn(Operand lhs, BasicBlock &currentBB, int64_t intVal)
+        : NonTerminatorInsn(std::move(lhs), currentBB), typeTag(TYPE_TAG_INT), value(intVal) {}
+    ConstantLoadInsn(Operand lhs, BasicBlock &currentBB, double doubleVal)
+        : NonTerminatorInsn(std::move(lhs), currentBB), typeTag(TYPE_TAG_FLOAT), value(doubleVal) {}
+    ConstantLoadInsn(Operand lhs, BasicBlock &currentBB, bool boolVal)
+        : NonTerminatorInsn(std::move(lhs), currentBB), typeTag(TYPE_TAG_BOOLEAN), value(boolVal) {}
+    ConstantLoadInsn(Operand lhs, BasicBlock &currentBB, std::string str)
+        : NonTerminatorInsn(std::move(lhs), currentBB), typeTag(TYPE_TAG_STRING), value(std::move(str)) {}
+    ConstantLoadInsn(Operand lhs, BasicBlock &currentBB)
+        : NonTerminatorInsn(std::move(lhs), currentBB), typeTag(TYPE_TAG_NIL) {}
     friend class NonTerminatorInsnCodeGen;
 };
 

--- a/compiler/include/bir/Function.h
+++ b/compiler/include/bir/Function.h
@@ -19,6 +19,9 @@
 #ifndef __FUNCTION__H__
 #define __FUNCTION__H__
 
+#include "bir/BasicBlock.h"
+#include "bir/FunctionParam.h"
+#include "bir/Operand.h"
 #include "bir/RestParam.h"
 #include "bir/Variable.h"
 #include "interfaces/Debuggable.h"
@@ -30,11 +33,6 @@
 
 namespace nballerina {
 
-class BasicBlock;
-class Operand;
-class FunctionParam;
-class InvocableType;
-class Type;
 class Package;
 
 class Function : public Debuggable {
@@ -42,24 +40,22 @@ class Function : public Debuggable {
     inline static const std::string MAIN_FUNCTION_NAME = "main";
     static constexpr unsigned int PUBLIC = 1;
     static constexpr unsigned int NATIVE = PUBLIC << 1;
-    Package &parentPackage;
+    Package *parentPackage;
     std::string name;
     std::string workerName;
     unsigned int flags;
     std::optional<Variable> returnVar;
     std::optional<RestParam> restParam;
     std::map<std::string, Variable> localVars;
-    std::vector<std::shared_ptr<BasicBlock>> basicBlocks;
+    std::vector<std::unique_ptr<BasicBlock>> basicBlocks;
     std::vector<FunctionParam> requiredParams;
 
   public:
-    Function() = delete;
-    Function(Package &parentPackage, std::string name, std::string workerName, unsigned int flags);
+    Function(Package *parentPackage, std::string name, std::string workerName, unsigned int flags);
     Function(const Function &) = delete;
-    Function(Function &&obj) noexcept = delete;
-    Function &operator=(const Function &obj) = delete;
-    Function &operator=(Function &&obj) noexcept = delete;
-    ~Function() = default;
+    Function(Function &&) noexcept = default;
+    Function &operator=(const Function &) = delete;
+    Function &operator=(Function &&) noexcept = default;
 
     const std::string &getName() const;
     size_t getNumParams() const;
@@ -71,10 +67,10 @@ class Function : public Debuggable {
     bool isExternalFunction() const;
     const std::vector<FunctionParam> &getParams() const;
 
-    void insertParam(const FunctionParam &param);
-    void setReturnVar(const Variable &var);
-    void insertLocalVar(const Variable &var);
-    void insertBasicBlock(const std::shared_ptr<BasicBlock> &bb);
+    void insertParam(FunctionParam param);
+    void setReturnVar(Variable var);
+    void insertLocalVar(Variable var);
+    void insertBasicBlock(std::unique_ptr<BasicBlock> bb);
 
     friend class FunctionCodeGen;
 };

--- a/compiler/include/bir/Function.h
+++ b/compiler/include/bir/Function.h
@@ -25,8 +25,6 @@
 #include "bir/RestParam.h"
 #include "bir/Variable.h"
 #include "interfaces/Debuggable.h"
-#include <map>
-#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -46,8 +44,8 @@ class Function : public Debuggable {
     unsigned int flags;
     std::optional<Variable> returnVar;
     std::optional<RestParam> restParam;
-    std::map<std::string, Variable> localVars;
-    std::vector<std::unique_ptr<BasicBlock>> basicBlocks;
+    std::vector<Variable> localVars;
+    std::vector<BasicBlock> basicBlocks;
     std::vector<FunctionParam> requiredParams;
 
   public:
@@ -67,12 +65,8 @@ class Function : public Debuggable {
     bool isExternalFunction() const;
     const std::vector<FunctionParam> &getParams() const;
 
-    void insertParam(FunctionParam param);
-    void setReturnVar(Variable var);
-    void insertLocalVar(Variable var);
-    void insertBasicBlock(std::unique_ptr<BasicBlock> bb);
-
     friend class FunctionCodeGen;
+    friend class BIRReader;
 };
 } // namespace nballerina
 

--- a/compiler/include/bir/FunctionCallInsn.h
+++ b/compiler/include/bir/FunctionCallInsn.h
@@ -33,14 +33,12 @@ class FunctionCallInsn : public TerminatorInsn, public Translatable<FunctionCall
     std::vector<Operand> argsList;
 
   public:
-    FunctionCallInsn() = delete;
-    FunctionCallInsn(BasicBlock &currentBB, std::string thenBBID, const Operand &lhs, std::string functionName,
-                     int argCount, std::vector<Operand> argsList)
-        : TerminatorInsn(lhs, currentBB, std::move(thenBBID)), functionName(std::move(functionName)),
+    FunctionCallInsn(BasicBlock &currentBB, std::string thenBBID, Operand lhs, std::string functionName, int argCount,
+                     std::vector<Operand> argsList)
+        : TerminatorInsn(std::move(lhs), currentBB, std::move(thenBBID)), functionName(std::move(functionName)),
           argCount(argCount), argsList(std::move(argsList)) {
         kind = INSTRUCTION_KIND_CALL;
     }
-    ~FunctionCallInsn() = default;
 
     friend class TerminatorInsnCodeGen;
 };

--- a/compiler/include/bir/FunctionParam.h
+++ b/compiler/include/bir/FunctionParam.h
@@ -31,10 +31,7 @@ class FunctionParam : public Operand {
     Type type;
 
   public:
-    FunctionParam() = delete;
     FunctionParam(Operand paramOp, Type type) : Operand(std::move(paramOp)), type(std::move(type)) {}
-    ~FunctionParam() = default;
-
     const Type &getType() const { return type; }
 };
 

--- a/compiler/include/bir/GoToInsn.h
+++ b/compiler/include/bir/GoToInsn.h
@@ -25,13 +25,10 @@ namespace nballerina {
 
 class GoToInsn : public TerminatorInsn, public Translatable<GoToInsn> {
   public:
-    GoToInsn() = delete;
     GoToInsn(BasicBlock &currentBB, std::string thenBBID)
         : TerminatorInsn(Operand("", NOT_A_KIND), currentBB, std::move(thenBBID)) {
         kind = INSTRUCTION_KIND_GOTO;
     }
-    ~GoToInsn() = default;
-
     friend class TerminatorInsnCodeGen;
 };
 

--- a/compiler/include/bir/InvocableType.h
+++ b/compiler/include/bir/InvocableType.h
@@ -34,10 +34,8 @@ class InvocableType {
     std::optional<Type> restType;
 
   public:
-    InvocableType() = delete;
-    InvocableType(std::vector<Type> paramTy, const Type &restTy, const Type &retTy);
-    InvocableType(std::vector<Type> paramTy, const Type &retTy);
-    ~InvocableType() = default;
+    InvocableType(std::vector<Type> paramTy, Type restTy, Type retTy);
+    InvocableType(std::vector<Type> paramTy, Type retTy);
 };
 
 } // namespace nballerina

--- a/compiler/include/bir/MapInsns.h
+++ b/compiler/include/bir/MapInsns.h
@@ -33,10 +33,7 @@ class MapConstruct {
         Operand expr;
 
       public:
-        SpreadField() = delete;
-        SpreadField(const Operand &expr) : expr(expr) {}
-        ~SpreadField() = default;
-
+        SpreadField(Operand expr) : expr(std::move(expr)) {}
         const Operand &getExpr() const { return expr; }
     };
     class KeyValue {
@@ -45,10 +42,7 @@ class MapConstruct {
         Operand valueOp;
 
       public:
-        KeyValue() = delete;
-        KeyValue(const Operand &key, const Operand &value) : keyOp(key), valueOp(value) {}
-        ~KeyValue() = default;
-
+        KeyValue(Operand key, Operand value) : keyOp(std::move(key)), valueOp(std::move(value)) {}
         const Operand &getKey() const { return keyOp; }
         const Operand &getValue() const { return valueOp; }
     };
@@ -58,10 +52,8 @@ class MapConstruct {
     std::variant<KeyValue, SpreadField> initValueStruct;
 
   public:
-    MapConstruct() = delete;
-    MapConstruct(KeyValue initVal) : kind(Key_Value_Kind), initValueStruct(initVal) {}
-    MapConstruct(SpreadField initVal) : kind(Spread_Field_Kind), initValueStruct(initVal) {}
-    virtual ~MapConstruct() = default;
+    MapConstruct(KeyValue initVal) : kind(Key_Value_Kind), initValueStruct(std::move(initVal)) {}
+    MapConstruct(SpreadField initVal) : kind(Spread_Field_Kind), initValueStruct(std::move(initVal)) {}
     MapConstrctBodyKind getKind() const { return kind; }
     const std::variant<KeyValue, SpreadField> &getInitValStruct() const { return initValueStruct; }
 };
@@ -72,10 +64,8 @@ class MapStoreInsn : public NonTerminatorInsn, public Translatable<MapStoreInsn>
     Operand rhsOp;
 
   public:
-    MapStoreInsn() = delete;
-    MapStoreInsn(const Operand &lhs, BasicBlock &currentBB, const Operand &KOp, const Operand &ROp)
-        : NonTerminatorInsn(lhs, currentBB), keyOp(KOp), rhsOp(ROp) {}
-    ~MapStoreInsn() = default;
+    MapStoreInsn(Operand lhs, BasicBlock &currentBB, Operand KOp, Operand ROp)
+        : NonTerminatorInsn(std::move(lhs), currentBB), keyOp(std::move(KOp)), rhsOp(std::move(ROp)) {}
     friend class NonTerminatorInsnCodeGen;
 };
 
@@ -85,10 +75,8 @@ class MapLoadInsn : public NonTerminatorInsn, public Translatable<MapLoadInsn> {
     Operand rhsOp;
 
   public:
-    MapLoadInsn() = delete;
-    MapLoadInsn(const Operand &lhs, BasicBlock &currentBB, const Operand &KOp, const Operand &ROp)
-        : NonTerminatorInsn(lhs, currentBB), keyOp(KOp), rhsOp(ROp) {}
-    ~MapLoadInsn() = default;
+    MapLoadInsn(Operand lhs, BasicBlock &currentBB, Operand KOp, Operand ROp)
+        : NonTerminatorInsn(std::move(lhs), currentBB), keyOp(std::move(KOp)), rhsOp(std::move(ROp)) {}
     friend class NonTerminatorInsnCodeGen;
 };
 } // namespace nballerina

--- a/compiler/include/bir/MoveInsn.h
+++ b/compiler/include/bir/MoveInsn.h
@@ -28,10 +28,8 @@ class MoveInsn : public NonTerminatorInsn, public Translatable<MoveInsn> {
     Operand rhsOp;
 
   public:
-    MoveInsn() = delete;
-    MoveInsn(const Operand &lhs, BasicBlock &currentBB, const Operand &rhsOp)
-        : NonTerminatorInsn(lhs, currentBB), rhsOp(rhsOp) {}
-    ~MoveInsn() = default;
+    MoveInsn(Operand lhs, BasicBlock &currentBB, Operand rhsOp)
+        : NonTerminatorInsn(std::move(lhs), currentBB), rhsOp(std::move(rhsOp)) {}
     friend class NonTerminatorInsnCodeGen;
 };
 

--- a/compiler/include/bir/Operand.h
+++ b/compiler/include/bir/Operand.h
@@ -26,9 +26,7 @@ namespace nballerina {
 
 class Operand : public AbstractVariable {
   public:
-    Operand() = delete;
     Operand(std::string name, VarKind kind) : AbstractVariable(std::move(name), kind) {}
-    virtual ~Operand() = default;
 };
 
 } // namespace nballerina

--- a/compiler/include/bir/Package.h
+++ b/compiler/include/bir/Package.h
@@ -39,9 +39,9 @@ class Package {
   public:
     Package() = default;
     Package(const Package &) = delete;
-    Package(Package &&) noexcept = default;
+    Package(Package &&) noexcept = delete;
     Package &operator=(const Package &) = delete;
-    Package &operator=(Package &&) noexcept = default;
+    Package &operator=(Package &&) noexcept = delete;
 
     std::string getModuleName() const;
     const Function &getFunction(const std::string &name) const;

--- a/compiler/include/bir/Package.h
+++ b/compiler/include/bir/Package.h
@@ -35,15 +35,14 @@ class Package {
     std::string version;
     std::string sourceFileName;
     std::map<std::string, Variable> globalVars;
-    std::map<std::string, std::shared_ptr<Function>> functionLookUp;
+    std::map<std::string, std::unique_ptr<Function>> functionLookUp;
 
   public:
     Package() = default;
-    virtual ~Package() = default;
     Package(const Package &) = delete;
-    Package(Package &&obj) noexcept = delete;
-    Package &operator=(const Package &obj) = delete;
-    Package &operator=(Package &&obj) noexcept = delete;
+    Package(Package &&) noexcept = default;
+    Package &operator=(const Package &) = delete;
+    Package &operator=(Package &&) noexcept = default;
 
     std::string getModuleName() const;
     const Function &getFunction(const std::string &name) const;
@@ -53,8 +52,8 @@ class Package {
     void setPackageName(std::string pkgName);
     void setVersion(std::string verName);
     void setSrcFileName(std::string srcFileName);
-    void insertGlobalVar(const Variable &var);
-    void insertFunction(const std::shared_ptr<Function> &function);
+    void insertGlobalVar(Variable var);
+    void insertFunction(std::unique_ptr<Function> function);
 
     friend class PackageCodeGen;
 };

--- a/compiler/include/bir/Package.h
+++ b/compiler/include/bir/Package.h
@@ -21,9 +21,8 @@
 
 #include "bir/Function.h"
 #include "bir/Variable.h"
-#include <map>
-#include <memory>
 #include <string>
+#include <vector>
 
 namespace nballerina {
 
@@ -34,8 +33,8 @@ class Package {
     std::string name;
     std::string version;
     std::string sourceFileName;
-    std::map<std::string, Variable> globalVars;
-    std::map<std::string, std::unique_ptr<Function>> functionLookUp;
+    std::vector<Variable> globalVars;
+    std::vector<Function> functions;
 
   public:
     Package() = default;
@@ -48,14 +47,8 @@ class Package {
     const Function &getFunction(const std::string &name) const;
     const Variable &getGlobalVariable(const std::string &name) const;
 
-    void setOrgName(std::string orgName);
-    void setPackageName(std::string pkgName);
-    void setVersion(std::string verName);
-    void setSrcFileName(std::string srcFileName);
-    void insertGlobalVar(Variable var);
-    void insertFunction(std::unique_ptr<Function> function);
-
     friend class PackageCodeGen;
+    friend class BIRReader;
 };
 
 } // namespace nballerina

--- a/compiler/include/bir/RestParam.h
+++ b/compiler/include/bir/RestParam.h
@@ -26,7 +26,6 @@ namespace nballerina {
 class RestParam {
   public:
     RestParam() = default;
-    ~RestParam() = default;
 };
 
 } // namespace nballerina

--- a/compiler/include/bir/ReturnInsn.h
+++ b/compiler/include/bir/ReturnInsn.h
@@ -26,8 +26,6 @@ namespace nballerina {
 class ReturnInsn : public TerminatorInsn, public Translatable<ReturnInsn> {
   public:
     ReturnInsn(class BasicBlock &currentBB) : TerminatorInsn(Operand("", NOT_A_KIND), currentBB, "") {}
-    ~ReturnInsn() = default;
-
     friend class TerminatorInsnCodeGen;
 };
 

--- a/compiler/include/bir/StructureInsn.h
+++ b/compiler/include/bir/StructureInsn.h
@@ -32,11 +32,9 @@ class StructureInsn : public NonTerminatorInsn, public Translatable<StructureIns
     std::vector<MapConstruct> initValues;
 
   public:
-    StructureInsn() = delete;
-    StructureInsn(const Operand &lhs, BasicBlock &currentBB) : NonTerminatorInsn(lhs, currentBB) {}
-    StructureInsn(const Operand &lhs, BasicBlock &currentBB, std::vector<MapConstruct> initValues)
-        : NonTerminatorInsn(lhs, currentBB), initValues(std::move(initValues)) {}
-    ~StructureInsn() = default;
+    StructureInsn(Operand lhs, BasicBlock &currentBB) : NonTerminatorInsn(std::move(lhs), currentBB) {}
+    StructureInsn(Operand lhs, BasicBlock &currentBB, std::vector<MapConstruct> initValues)
+        : NonTerminatorInsn(std::move(lhs), currentBB), initValues(std::move(initValues)) {}
     friend class NonTerminatorInsnCodeGen;
 };
 

--- a/compiler/include/bir/TypeCastInsn.h
+++ b/compiler/include/bir/TypeCastInsn.h
@@ -30,10 +30,8 @@ class TypeCastInsn : public NonTerminatorInsn, public Translatable<TypeCastInsn>
     Operand rhsOp;
 
   public:
-    TypeCastInsn() = delete;
-    TypeCastInsn(const Operand &lhs, BasicBlock &currentBB, const Operand &rhsOp)
-        : NonTerminatorInsn(lhs, currentBB), rhsOp(rhsOp) {}
-    ~TypeCastInsn() = default;
+    TypeCastInsn(Operand lhs, BasicBlock &currentBB, Operand rhsOp)
+        : NonTerminatorInsn(std::move(lhs), currentBB), rhsOp(std::move(rhsOp)) {}
     friend class NonTerminatorInsnCodeGen;
 };
 

--- a/compiler/include/bir/TypeDescInsn.h
+++ b/compiler/include/bir/TypeDescInsn.h
@@ -25,8 +25,7 @@ namespace nballerina {
 
 class TypeDescInsn : public NonTerminatorInsn, public Translatable<TypeDescInsn> {
   public:
-    TypeDescInsn(const Operand &lhs, BasicBlock &currentBB) : NonTerminatorInsn(lhs, currentBB){};
-    ~TypeDescInsn() = default;
+    TypeDescInsn(Operand lhs, BasicBlock &currentBB) : NonTerminatorInsn(std::move(lhs), currentBB){};
     friend class NonTerminatorInsnCodeGen;
 };
 

--- a/compiler/include/bir/TypeTestInsn.h
+++ b/compiler/include/bir/TypeTestInsn.h
@@ -26,9 +26,7 @@ namespace nballerina {
 class TypeTestInsn : public NonTerminatorInsn, public Translatable<TypeTestInsn> {
 
   public:
-    TypeTestInsn() = delete;
-    TypeTestInsn(const class Operand &lhs, BasicBlock &currentBB) : NonTerminatorInsn(lhs, currentBB) {}
-    ~TypeTestInsn() = default;
+    TypeTestInsn(class Operand lhs, BasicBlock &currentBB) : NonTerminatorInsn(std::move(lhs), currentBB) {}
     friend class NonTerminatorInsnCodeGen;
 };
 

--- a/compiler/include/bir/Types.h
+++ b/compiler/include/bir/Types.h
@@ -98,11 +98,9 @@ class Type {
     std::variant<ArrayType, MapType> typeInfo;
 
   public:
-    Type() = delete;
     Type(TypeTag type, std::string namep);
     Type(TypeTag type, std::string namep, ArrayType arrayType);
     Type(TypeTag type, std::string namep, MapType mapType);
-    virtual ~Type() = default;
 
     TypeTag getTypeTag() const;
     TypeTag getMemberTypeTag() const;

--- a/compiler/include/bir/UnaryOpInsn.h
+++ b/compiler/include/bir/UnaryOpInsn.h
@@ -31,10 +31,8 @@ class UnaryOpInsn : public NonTerminatorInsn, public Translatable<UnaryOpInsn> {
     InstructionKind kind;
 
   public:
-    UnaryOpInsn() = delete;
-    UnaryOpInsn(const Operand &lhs, BasicBlock &currentBB, const Operand &rhs)
-        : NonTerminatorInsn(lhs, currentBB), rhsOp(rhs) {}
-    ~UnaryOpInsn() = default;
+    UnaryOpInsn(Operand lhs, BasicBlock &currentBB, Operand rhs)
+        : NonTerminatorInsn(std::move(lhs), currentBB), rhsOp(std::move(rhs)) {}
     void setInstKind(InstructionKind kind) { this->kind = kind; }
     friend class NonTerminatorInsnCodeGen;
 };

--- a/compiler/include/bir/Variable.h
+++ b/compiler/include/bir/Variable.h
@@ -19,8 +19,8 @@
 #ifndef __VARIABLE__H__
 #define __VARIABLE__H__
 
-#include "interfaces/AbstractVariable.h"
 #include "bir/Types.h"
+#include "interfaces/AbstractVariable.h"
 #include <memory>
 #include <string>
 
@@ -31,14 +31,12 @@ class Variable : public AbstractVariable {
     Type type;
 
   public:
-    Variable() = delete;
     Variable(Type type, std::string name, VarKind kind)
         : AbstractVariable(std::move(name), kind), type(std::move(type)) {}
-    virtual ~Variable() = default;
 
     const Type &getType() const { return type; }
     bool isParamter() const {
-        switch (getKind()) {
+        switch (kind) {
         case ARG_VAR_KIND:
             return true;
         default:

--- a/compiler/include/interfaces/AbstractInstruction.h
+++ b/compiler/include/interfaces/AbstractInstruction.h
@@ -19,14 +19,13 @@
 #ifndef __ABSTRACTINSN__H__
 #define __ABSTRACTINSN__H__
 
-#include "bir/BasicBlock.h"
 #include "bir/Operand.h"
 #include "interfaces/Debuggable.h"
 
 namespace nballerina {
 
 class Function;
-class Package;
+class BasicBlock;
 
 enum InstructionKind {
     INSTRUCTION_NOT_AN_INSTRUCTION = 0,
@@ -76,11 +75,14 @@ class AbstractInstruction : public Debuggable {
 
   protected:
     Operand lhsOp;
-    const Function &getFunctionRef() const { return parentBB.getParentFunctionRef(); }
+    const Function &getFunctionRef() const;
 
   public:
-    AbstractInstruction() = delete;
-    AbstractInstruction(const Operand &lOp, BasicBlock &parentBB) : parentBB(parentBB), lhsOp(lOp) {}
+    AbstractInstruction(Operand lOp, BasicBlock &parentBB);
+    AbstractInstruction(const AbstractInstruction &) = delete;
+    AbstractInstruction(AbstractInstruction &&) noexcept = delete;
+    AbstractInstruction &operator=(const AbstractInstruction &) = delete;
+    AbstractInstruction &operator=(AbstractInstruction &&) noexcept = delete;
     virtual ~AbstractInstruction() = default;
 };
 

--- a/compiler/include/interfaces/AbstractVariable.h
+++ b/compiler/include/interfaces/AbstractVariable.h
@@ -36,13 +36,16 @@ enum VarKind {
 };
 
 class AbstractVariable {
-  private:
+  protected:
     std::string name;
     VarKind kind;
+    AbstractVariable(std::string name, VarKind kind) : name(std::move(name)), kind(kind) {}
+    AbstractVariable(const AbstractVariable &) = delete;
+    AbstractVariable(AbstractVariable &&) noexcept = default;
+    AbstractVariable &operator=(const AbstractVariable &) = delete;
+    AbstractVariable &operator=(AbstractVariable &&) noexcept = default;
 
   public:
-    AbstractVariable() = delete;
-    AbstractVariable(std::string name, VarKind kind) : name(std::move(name)), kind(kind) {}
     virtual ~AbstractVariable() = default;
 
     VarKind getKind() const { return kind; }

--- a/compiler/include/interfaces/Debuggable.h
+++ b/compiler/include/interfaces/Debuggable.h
@@ -27,8 +27,6 @@ class Debuggable {
     Location pos;
 
   public:
-    Debuggable() = default;
-    virtual ~Debuggable() = default;
     const Location &getLocation() const { return pos; };
     void setLocation(Location newPos) { pos = std::move(newPos); };
 };

--- a/compiler/include/interfaces/NonTerminatorInsn.h
+++ b/compiler/include/interfaces/NonTerminatorInsn.h
@@ -24,13 +24,11 @@
 
 namespace nballerina {
 
-// Forward Declaration
-class Operand;
-
 class NonTerminatorInsn : public AbstractInstruction, virtual public TranslatableInterface {
+  protected:
+    NonTerminatorInsn(Operand lOp, BasicBlock &currentBB) : AbstractInstruction(std::move(lOp), currentBB) {}
+
   public:
-    NonTerminatorInsn() = delete;
-    NonTerminatorInsn(const Operand &lOp, BasicBlock &currentBB) : AbstractInstruction(lOp, currentBB) {}
     virtual ~NonTerminatorInsn() = default;
 };
 

--- a/compiler/include/interfaces/TerminatorInsn.h
+++ b/compiler/include/interfaces/TerminatorInsn.h
@@ -26,20 +26,15 @@
 namespace nballerina {
 
 class TerminatorInsn : public AbstractInstruction, virtual public TranslatableInterface {
-  private:
-    std::string thenBBID;
-
   protected:
+    std::string thenBBID;
     InstructionKind kind;
+    TerminatorInsn(class Operand lhs, class BasicBlock &currentBB, std::string thenBBID)
+        : AbstractInstruction(std::move(lhs), currentBB), thenBBID(std::move(thenBBID)),
+          kind(INSTRUCTION_NOT_AN_INSTRUCTION) {}
 
   public:
-    TerminatorInsn() = delete;
-    TerminatorInsn(const class Operand &lhs, class BasicBlock &currentBB, std::string thenBBID)
-        : AbstractInstruction(lhs, currentBB), thenBBID(std::move(thenBBID)), kind(INSTRUCTION_NOT_AN_INSTRUCTION) {}
     virtual ~TerminatorInsn() = default;
-
-    const std::string &getNextBBID() const { return thenBBID; }
-    InstructionKind getInstKind() const { return kind; }
 };
 
 } // namespace nballerina


### PR DESCRIPTION
## Purpose
Description #289 

Resolves #289 

## Approach
**Changes**
* Disable copying but allow moving for `AbstractVariable` derived classes and `Function` & `BasicBlock` classes
* `Function` & `BasicBlock` classes are no longer heap allocated to improve performance
* Disable copying and moving for `Package` class since we heap allocate it
* Disable copying and moving for `AbstractInstruction` derived classes since we must heap allocate them anyway to get the double dispatch (observer pattern) working
* Made BIRReader class a friend of `Package`, `Function` and `BasicBlock` classes to simplify BIR class interfaces and to improve their invariance
* Address some warnings thrown by the static analyser for the `BIRReader` class