### PR TITLE
[Hotfix] Specify Rust version used for PR check

### DIFF
--- a/.github/workflows/PRCheck.yml
+++ b/.github/workflows/PRCheck.yml
@@ -13,8 +13,14 @@ jobs:
       - name: Install utils
         run: | 
           sudo apt update
-          sudo apt install -y build-essential llvm-11-dev lld-11 cmake cargo python3-pip
+          sudo apt install -y build-essential llvm-11-dev lld-11 cmake python3-pip
           pip3 install lit filecheck
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: 1.49.0
+            override: true
 
       - name: Install JRE 11
         uses: actions/setup-java@v1

--- a/.github/workflows/PRCheck.yml
+++ b/.github/workflows/PRCheck.yml
@@ -14,8 +14,6 @@ jobs:
         run: | 
           sudo apt update
           sudo apt install -y build-essential llvm-11-dev lld-11 cmake cargo python3-pip
-          cargo install cbindgen
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
           pip3 install lit filecheck
 
       - name: Install JRE 11
@@ -32,10 +30,6 @@ jobs:
         run: | 
           cmake -DCMAKE_BUILD_TYPE=Release -S . -B build/
           cmake --build ./build/ -- -j
-      
-      - name: Build runtime header
-        run: | 
-          cmake --build ./build/ -t runtime_header
       
       - name: Setup Ballerina pack
         run: |


### PR DESCRIPTION
## Purpose

Rust stable (1.52) now uses LLVM 12 and breaks our build workflow which require LLVM 11.
This PR updates the Ubuntu build workflow to use Rust version 1.49.0 (which uses LLVM 11) instead of stable.

This PR also disable the unused cbindgen target to build the c header file for the Rust runtime.