### PR TITLE
Add LLVM module and function verification passes

### DIFF
--- a/compiler/codegen/FunctionCodeGen.cpp
+++ b/compiler/codegen/FunctionCodeGen.cpp
@@ -22,6 +22,7 @@
 #include "bir/FunctionParam.h"
 #include "codegen/BasicBlockCodeGen.h"
 #include "codegen/CodeGenUtils.h"
+#include <llvm/IR/Verifier.h>
 
 namespace nballerina {
 
@@ -101,5 +102,10 @@ void FunctionCodeGen::visit(Function &obj, llvm::IRBuilder<> &builder) {
         BasicBlockCodeGen generator(*this, parentGenerator);
         generator.visit(bb, builder);
     }
+
+    if (llvm::verifyFunction(*llvmFunction, &llvm::outs())) {
+        llvm_unreachable("LLVM function verification failed");
+    };
 }
+
 } // namespace nballerina

--- a/compiler/codegen/FunctionCodeGen.cpp
+++ b/compiler/codegen/FunctionCodeGen.cpp
@@ -103,9 +103,7 @@ void FunctionCodeGen::visit(Function &obj, llvm::IRBuilder<> &builder) {
         generator.visit(bb, builder);
     }
 
-    if (llvm::verifyFunction(*llvmFunction, &llvm::outs())) {
-        llvm_unreachable("LLVM function verification failed");
-    };
+    assert(!llvm::verifyFunction(*llvmFunction, &llvm::outs()));
 }
 
 } // namespace nballerina

--- a/compiler/codegen/PackageCodeGen.cpp
+++ b/compiler/codegen/PackageCodeGen.cpp
@@ -91,9 +91,7 @@ void PackageCodeGen::visit(Package &obj, llvm::IRBuilder<> &builder) {
         globalStrTable->setInitializer(llvm::dyn_cast<llvm::Constant>(bitCastRes));
     }
 
-    if (llvm::verifyModule(module, &llvm::outs())) {
-        llvm_unreachable("LLVM module verification failed");
-    };
+    assert(!llvm::verifyModule(module, &llvm::outs()));
 }
 
 void PackageCodeGen::storeValueInSmartStruct(llvm::IRBuilder<> &builder, llvm::Value *value, const Type &valueType,

--- a/compiler/codegen/PackageCodeGen.cpp
+++ b/compiler/codegen/PackageCodeGen.cpp
@@ -21,7 +21,7 @@
 #include "bir/Package.h"
 #include "codegen/CodeGenUtils.h"
 #include "codegen/FunctionCodeGen.h"
-#include <iostream>
+#include <llvm/IR/Verifier.h>
 
 namespace nballerina {
 
@@ -90,6 +90,10 @@ void PackageCodeGen::visit(Package &obj, llvm::IRBuilder<> &builder) {
         auto *bitCastRes = builder.CreateBitCast(globalStrTable2, charPtrType, "");
         globalStrTable->setInitializer(llvm::dyn_cast<llvm::Constant>(bitCastRes));
     }
+
+    if (llvm::verifyModule(module, &llvm::outs())) {
+        llvm_unreachable("LLVM module verification failed");
+    };
 }
 
 void PackageCodeGen::storeValueInSmartStruct(llvm::IRBuilder<> &builder, llvm::Value *value, const Type &valueType,


### PR DESCRIPTION
## Purpose

Add LLVM module and function verify passes to catch bugs early. i.e. without having to rely on clang compile to catch issues.

These verification passes will output easy to diagnose messages like:
```
Incorrect number of arguments passed to called function!
  %14 = call i8 @map_load_anydata(i8* %"%1_temp11", i8* %"%13_temp12")
LLVM function verification failed
UNREACHABLE executed at .. nballerina/compiler/codegen/FunctionCodeGen.cpp:107!
Aborted (core dumped)
```

Resolves #311 