### PR TITLE
Move build artifacts to a separate directory

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,4 +1,0 @@
-/*.ll
-v*-expect.txt
-v*-actual.txt
-v*-diff.txt

--- a/tests/clean.sh
+++ b/tests/clean.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-rm -f V*-actual.txt V*-expect.txt V*-diff.txt V*.ll
+rm -rf "`dirname "$0"`/target"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
-clang-11 -Wno-override-module $1 ../runtime/balrt.c && ./a.out
+tests=`dirname "$0"`
+t="$tests/target"
+mkdir -p "$t"
+clang-11 -Wno-override-module "$1" "$tests/../runtime/balrt.c" -o "$t/$b.out"  && "$t/$b.out"

--- a/tests/testll.sh
+++ b/tests/testll.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 # This expects to be run on Linux
-for f in V*.ll
+tests=`dirname "$0"`
+t="$tests/target"
+mkdir -p "$t"
+for f in "$tests"/ll/V*.ll
 do
-    b=`basename $f .ll`
-    sed -ne 's;^.* // *@output  *;;p' $b.bal | tr -d '\r' > $b-expect.txt
-    clang-11 -Wno-override-module $f ../runtime/balrt.c && ./a.out > $b-actual.txt
-    diff $b-expect.txt $b-actual.txt >$b-diff.txt || echo $b failed
+    b=`basename "$f" .ll`
+    sed -ne 's;^.* // *@output  *;;p' "$tests/$b.bal" | tr -d '\r' > "$t/$b-expect.txt"
+    clang-11 -Wno-override-module "$f" "$tests/../runtime/balrt.c" -o "$t/$b.out"  && "$t/$b.out" > "$t/$b-actual.txt"
+    diff "$t/$b-expect.txt" "$t/$b-actual.txt" >"$t/$b-diff.txt" || echo $b failed
 done


### PR DESCRIPTION
This pr will

- Move build artifacts to a separate directory to keep the source dirs clean.
- [Quote](http://mywiki.wooledge.org/Quotes) variables to avoid potential issues 
- Make it possible to run from the root of the repository