### PR TITLE
Parse right shift operator

### DIFF
--- a/compiler/modules/front/ast.bal
+++ b/compiler/modules/front/ast.bal
@@ -73,12 +73,14 @@ type BinaryArithmeticOp "+" | "-" | "*" | "/" | "%";
 type BinaryBitwiseOp "|" | "^" | "&";
 type BinaryRelationalOp "<" | ">" | "<=" | ">=";
 type BinaryEqualityOp  "==" | "!=" | "===" | "!==";
+type BinaryShiftOp  "<<" | ">>" | ">>>";
+
 
 type BinaryExprOp BinaryArithmeticOp|BinaryRelationalOp|BinaryEqualityOp;
 
 type UnaryExprOp "-" | "!";
 
-type BinaryExpr BinaryRelationalExpr|BinaryEqualityExpr|BinaryArithmeticExpr|BinaryBitwiseExpr;
+type BinaryExpr BinaryRelationalExpr|BinaryEqualityExpr|BinaryArithmeticExpr|BinaryBitwiseExpr|BinaryShiftExpr;
 
 // We use different operator names so things work better with match statements
 type BinaryExprBase record {|
@@ -100,6 +102,11 @@ type BinaryArithmeticExpr record {|
     *BinaryExprBase;
     BinaryArithmeticOp arithmeticOp;
     err:Position pos;
+|};
+
+type BinaryShiftExpr record {|
+    *BinaryExprBase;
+    BinaryShiftOp shiftOp;
 |};
 
 type BinaryBitwiseExpr record {|

--- a/compiler/modules/front/astString.bal
+++ b/compiler/modules/front/astString.bal
@@ -165,6 +165,9 @@ function exprToWords(Word[] w, Expr expr, boolean wrap = false) {
         else if expr is BinaryRelationalExpr {
             op = expr.relationalOp;
         }
+        else if expr is BinaryShiftExpr {
+            op = expr.shiftOp;
+        }
         else {
             op = expr.equalityOp;
         }

--- a/compiler/modules/front/parseExpr.bal
+++ b/compiler/modules/front/parseExpr.bal
@@ -73,17 +73,30 @@ function parseEqualityExpr(Tokenizer tok)  returns Expr|err:Syntax {
 }
 
 function parseRelationalExpr(Tokenizer tok) returns Expr|err:Syntax {
-    Expr expr = check parseAdditiveExpr(tok);
+    Expr expr = check parseShiftExpr(tok);
     Token? t = tok.current();
     if t is BinaryRelationalOp {
         check tok.advance();
-        Expr right = check parseAdditiveExpr(tok);
+        Expr right = check parseShiftExpr(tok);
         BinaryRelationalExpr bin = { relationalOp: t, left: expr, right };
         return bin;
     }
     else {
         return expr;
     }
+}
+
+function parseShiftExpr(Tokenizer tok) returns Expr|err:Syntax {
+    Expr expr = check parseAdditiveExpr(tok);
+    Token? t = tok.current();
+    if t is ">" && tok.peek() is ">"  {
+        check tok.advance();
+        check tok.advance();
+        Expr right = check parseAdditiveExpr(tok);
+        BinaryShiftExpr shift = { shiftOp: ">>", left: expr, right };
+        return shift;
+    }
+    return expr;
 }
 
 function parseAdditiveExpr(Tokenizer tok) returns Expr|err:Syntax {

--- a/compiler/modules/front/tests/testParser.bal
+++ b/compiler/modules/front/tests/testParser.bal
@@ -245,6 +245,7 @@ function validTokenSourceFragments() returns string[][]|error {
          ["V", "expr", "a +\r b", "a + b"],
          ["V", "expr", "a +\r\n b", "a + b"],
          ["V", "expr", "a +\n\r b", "a + b"],
+         ["V", "expr", "a >> b", "a >> b"],
          ["V", "expr", "a | b", "a | b"],
          ["V", "expr", "a & b", "a & b"],
          ["V", "expr", "a ^ b", "a ^ b"],


### PR DESCRIPTION
Part of  #103

# Apporch
Options to handle `>>`

1) Lexer pass it as `>>` and parser has multiple rules 
(https://homepages.inf.ed.ac.uk/wadler/gj/Documents/gj-specification.pdf section 2.3)
Cons: make the parser rules convoluted.

2) Tokenizer parse it as two `>`s, paser combines them
    2.1) Unget tokens - I tried adding a `retreat` function. Restore `cur`, `startIndex`, `lineStartIndex` and `lineNumber` in `retreat`
    2.2) Peek - Extend unget to multiple char, use that to feed back the peeked chars.

3) Have conditional behavior in tokenizer and control it from the parser.


2.2 felt slightly cleaner than 2.1, so I did that.

Does this look OK to you?