### PR TITLE
Add a test to put a map element in a function

### DIFF
--- a/compiler/testSuite/Vmapping09.bal
+++ b/compiler/testSuite/Vmapping09.bal
@@ -1,0 +1,16 @@
+import ballerina/io;
+
+public function main() {
+    map<any> m = {};
+    put(m, "five", 5);
+    io:println(get(m, "five")); // @output 5
+}
+
+function put(map<any> m, string k, int v) {
+    m[k] = v;
+}
+
+
+function get(map<any> m, string k) returns int{
+    return <int> m[k];
+}


### PR DESCRIPTION
Add a test to put a map element in a function

Failing right now, I believe this is a bug.