### PR TITLE
Refactor enumerable to be able to support `string:Char`

### DIFF
--- a/compiler/modules/types/enumerable.bal
+++ b/compiler/modules/types/enumerable.bal
@@ -1,11 +1,9 @@
-import wso2/nballerina.err;
-
 // EnumerableTypes are types in which each expressible subtype can be reasonably
 // represented by a list of values. counter-eg: `int` is not a EnumerableType since
 // uint32 can't be reasonably represented by listing all values.
 type EnumerableType float|string;
 
-type EnumerableSubType FloatSubtype|StringSubtype;
+type EnumerableSubtype FloatSubtype|StringSubtype;
 
 const LT = -1;
 const EQ = 0;
@@ -13,54 +11,52 @@ const GT = 1;
 
 type Order GT|EQ|LT;
 
-function enumerableSubtypeUnion(EnumerableSubType t1, EnumerableSubType t2) returns SubtypeData {
+function enumerableSubtypeUnion(EnumerableSubtype t1, EnumerableSubtype t2, EnumerableType[] result) returns boolean {
     boolean b1 = t1.allowed;
     boolean b2 = t2.allowed;
     boolean allowed;
-    EnumerableType[] values = arrayOfType(t1.values);
     if b1 && b2 {
-        enumerableListUnion(t1.values, t2.values, values);
+        enumerableListUnion(t1.values, t2.values, result);
         allowed = true;
     }
     else if !b1 && !b2 {
-        enumerableListIntersect(t1.values, t2.values, values);
+        enumerableListIntersect(t1.values, t2.values, result);
         allowed = false;
     }
     else if b1 && !b2 {
-        enumerableListDiff(t2.values, t1.values, values);
+        enumerableListDiff(t2.values, t1.values, result);
         allowed = false;
     }
     else {
          // !b1 && b2
-        enumerableListDiff(t1.values, t2.values, values);
+        enumerableListDiff(t1.values, t2.values, result);
         allowed = false;
     }
-    return createEnumerableSubtype(allowed, values);
+    return allowed;
 }
 
-function enumerableSubtypeIntersect(EnumerableSubType t1, EnumerableSubType t2) returns SubtypeData {
+function enumerableSubtypeIntersect(EnumerableSubtype t1, EnumerableSubtype t2, EnumerableType[] result) returns boolean {
     boolean b1 = t1.allowed;
     boolean b2 = t2.allowed;
     boolean allowed;
-    EnumerableType[] values = arrayOfType(t1.values);
     if b1 && b2 {
-        enumerableListIntersect(t1.values, t2.values, values);
+        enumerableListIntersect(t1.values, t2.values, result);
         allowed = true;
     }
     else if !b1 && !b2 {
-        enumerableListUnion(t1.values, t2.values, values);
+        enumerableListUnion(t1.values, t2.values, result);
         allowed = false;
     }
     else if b1 && !b2 {
-        enumerableListDiff(t1.values, t2.values, values);
+        enumerableListDiff(t1.values, t2.values, result);
         allowed = true;
     }
     else {
         // !b1 && b2
-        enumerableListDiff(t2.values, t1.values, values);
+        enumerableListDiff(t2.values, t1.values, result);
         allowed = true;
     }
-    return createEnumerableSubtype(allowed, values);
+    return allowed;
 }
 
 function enumerableListUnion(EnumerableType[] v1, EnumerableType[] v2, EnumerableType[] result) {
@@ -199,27 +195,4 @@ function floatEq(float f1, float f2) returns boolean {
         }
     }
     return f1 == f2;
-}
-
-function arrayOfType(EnumerableType[] arr) returns EnumerableType[] {
-    if arr is string[] {
-        string[] res =  [];
-        return res;
-    }
-    else if arr is float[] {
-        float[] res =  [];
-        return res;
-    }
-    panic err:impossible();
-}
-
-
-function createEnumerableSubtype(boolean allowed, EnumerableType[] values) returns SubtypeData {
-    if values is string[] {
-        return createStringSubtype(allowed, values);
-    }
-    else if values is float[] {
-        return createFloatSubtype(allowed, values);
-    }
-    panic err:impossible();
 }

--- a/compiler/modules/types/float.bal
+++ b/compiler/modules/types/float.bal
@@ -13,13 +13,13 @@ public function floatConst(float value) returns SemType {
 function floatSubtypeUnion(SubtypeData d1, SubtypeData d2) returns SubtypeData {
     float[] values = [];
     boolean allowed = enumerableSubtypeUnion(<FloatSubtype>d1, <FloatSubtype>d2, values);
-    return { allowed, values: values.cloneReadOnly() };
+    return createFloatSubtype(allowed, values);
 }
 
 function floatSubtypeIntersect(SubtypeData d1, SubtypeData d2) returns SubtypeData {
     float[] values = [];
     boolean allowed = enumerableSubtypeIntersect(<FloatSubtype>d1, <FloatSubtype>d2, values);
-    return { allowed, values: values.cloneReadOnly() };
+    return createFloatSubtype(allowed, values);
 }
 
 function floatSubtypeDiff(SubtypeData d1, SubtypeData d2) returns SubtypeData {

--- a/compiler/modules/types/float.bal
+++ b/compiler/modules/types/float.bal
@@ -10,9 +10,21 @@ public function floatConst(float value) returns SemType {
     return uniformSubtype(UT_FLOAT, st);
 }
 
-function floatSubtypeIntersect(SubtypeData d1, SubtypeData d2) returns SubtypeData =>
-    enumerableSubtypeIntersect(<FloatSubtype>d1, <FloatSubtype>d2);
+function floatSubtypeUnion(SubtypeData d1, SubtypeData d2) returns SubtypeData {
+    float[] values = [];
+    boolean allowed = enumerableSubtypeUnion(<FloatSubtype>d1, <FloatSubtype>d2, values);
+    return { allowed, values: values.cloneReadOnly() };
+}
 
+function floatSubtypeIntersect(SubtypeData d1, SubtypeData d2) returns SubtypeData {
+    float[] values = [];
+    boolean allowed = enumerableSubtypeIntersect(<FloatSubtype>d1, <FloatSubtype>d2, values);
+    return { allowed, values: values.cloneReadOnly() };
+}
+
+function floatSubtypeDiff(SubtypeData d1, SubtypeData d2) returns SubtypeData {
+    return floatSubtypeIntersect(d1, floatSubtypeComplement(d2));
+}
 
 function floatSubtypeComplement(SubtypeData d) returns SubtypeData {
     FloatSubtype s = <FloatSubtype>d;
@@ -28,11 +40,9 @@ function createFloatSubtype(boolean allowed, float[] values) returns SubtypeData
 }
 
 final UniformTypeOps floatOps = {
-    union: function (SubtypeData d1, SubtypeData d2) returns SubtypeData =>
-               enumerableSubtypeUnion(<FloatSubtype>d1, <FloatSubtype>d2),
-    diff: function (SubtypeData d1, SubtypeData d2) returns SubtypeData =>
-               floatSubtypeIntersect(d1, floatSubtypeComplement(d2)),
+    union: floatSubtypeUnion,
     intersect: floatSubtypeIntersect,
+    diff: floatSubtypeDiff,
     complement: floatSubtypeComplement,
     // Empty float sets don't use subtype representation.
     isEmpty: notIsEmpty

--- a/compiler/modules/types/string.bal
+++ b/compiler/modules/types/string.bal
@@ -36,13 +36,13 @@ function stringSubtypeContains(SubtypeData d, string s) returns boolean {
 function stringSubtypeUnion(SubtypeData d1, SubtypeData d2) returns SubtypeData {
     string[] values = [];
     boolean allowed = enumerableSubtypeUnion(<StringSubtype>d1, <StringSubtype>d2, values);
-    return { allowed, values: values.cloneReadOnly() };
+    return createStringSubtype(allowed, values);
 }
 
 function stringSubtypeIntersect(SubtypeData d1, SubtypeData d2) returns SubtypeData {
     string[] values = [];
     boolean allowed = enumerableSubtypeIntersect(<StringSubtype>d1, <StringSubtype>d2, values);
-    return { allowed, values: values.cloneReadOnly() };
+    return createStringSubtype(allowed, values);
 }
 
 function stringSubtypeDiff(SubtypeData d1, SubtypeData d2) returns SubtypeData {

--- a/compiler/modules/types/string.bal
+++ b/compiler/modules/types/string.bal
@@ -33,8 +33,21 @@ function stringSubtypeContains(SubtypeData d, string s) returns boolean {
     return v.values.indexOf(s) != () ? v.allowed : !v.allowed;
 }
 
-function stringSubtypeIntersect(SubtypeData d1, SubtypeData d2) returns SubtypeData =>
-    enumerableSubtypeIntersect(<StringSubtype>d1, <StringSubtype>d2);
+function stringSubtypeUnion(SubtypeData d1, SubtypeData d2) returns SubtypeData {
+    string[] values = [];
+    boolean allowed = enumerableSubtypeUnion(<StringSubtype>d1, <StringSubtype>d2, values);
+    return { allowed, values: values.cloneReadOnly() };
+}
+
+function stringSubtypeIntersect(SubtypeData d1, SubtypeData d2) returns SubtypeData {
+    string[] values = [];
+    boolean allowed = enumerableSubtypeIntersect(<StringSubtype>d1, <StringSubtype>d2, values);
+    return { allowed, values: values.cloneReadOnly() };
+}
+
+function stringSubtypeDiff(SubtypeData d1, SubtypeData d2) returns SubtypeData {
+    return stringSubtypeIntersect(d1, stringSubtypeComplement(d2));
+}
 
 function stringSubtypeComplement(SubtypeData d) returns SubtypeData {
     StringSubtype s = <StringSubtype>d;
@@ -50,11 +63,9 @@ function createStringSubtype(boolean allowed, string[] values) returns SubtypeDa
 }
 
 final UniformTypeOps stringOps = {
-    union: function (SubtypeData d1, SubtypeData d2) returns SubtypeData =>
-            enumerableSubtypeUnion(<StringSubtype>d1, <StringSubtype>d2),
-    diff: function (SubtypeData d1, SubtypeData d2) returns SubtypeData =>
-            stringSubtypeIntersect(d1, stringSubtypeComplement(d2)),
+    union: stringSubtypeUnion,
     intersect: stringSubtypeIntersect,
+    diff: stringSubtypeDiff,
     complement: stringSubtypeComplement,
     // Empty string sets don't use subtype representation.
     isEmpty: notIsEmpty


### PR DESCRIPTION
Refactor enumerable in perpetration for`string:Char` in #292.
Should have been part of #284.