### PR TITLE
Allow floating point literals in expressions

### DIFF
--- a/compiler/modules/front.syntax/ast.bal
+++ b/compiler/modules/front.syntax/ast.bal
@@ -39,7 +39,7 @@ public type ConstDefn record {|
 
 public type Stmt VarDeclStmt|AssignStmt|CallStmt|ReturnStmt|IfElseStmt|MatchStmt|WhileStmt|ForeachStmt|BreakStmt|ContinueStmt;
 public type CallStmt FunctionCallExpr|MethodCallExpr;
-public type Expr IntLiteralExpr|ConstValueExpr|BinaryExpr|UnaryExpr|FunctionCallExpr|MethodCallExpr|VarRefExpr|TypeCastExpr|TypeTestExpr|ConstructorExpr|MemberAccessExpr;
+public type Expr NumericLiteralExpr|ConstValueExpr|BinaryExpr|UnaryExpr|FunctionCallExpr|MethodCallExpr|VarRefExpr|TypeCastExpr|TypeTestExpr|ConstructorExpr|MemberAccessExpr;
 public type ConstructorExpr ListConstructorExpr|MappingConstructorExpr;
 public type SimpleConstExpr ConstValueExpr|VarRefExpr|IntLiteralExpr|SimpleConstNegateExpr;
 
@@ -228,7 +228,7 @@ public type TypeTestExpr record {|
 |};
 
 public type ConstValueExpr record {|
-    ()|boolean|int|string value;
+    ()|boolean|int|float|string value;
     // This is non-nil when the static public type of the expression
     // contains more than one shape.
     // When it contains exactly one shape, then the shape is
@@ -266,7 +266,7 @@ public type InlineTypeDesc InlineLeafTypeDesc|InlineArrayTypeDesc|InlineMapTypeD
 
 public const ANY = "any";
 
-public type InlineLeafTypeDesc "boolean"|"int"|"string"|ANY;
+public type InlineLeafTypeDesc "boolean"|"int"|"float"|"string"|ANY;
 
 public type InlineArrayTypeDesc record {|
     *ListTypeDesc;

--- a/compiler/modules/front.syntax/astString.bal
+++ b/compiler/modules/front.syntax/astString.bal
@@ -235,6 +235,9 @@ function exprToWords(Word[] w, Expr expr, boolean wrap = false) {
             w.push(expr.digits);
         }
     }
+    else if expr is FpLiteralExpr {
+        w.push(expr.untypedLiteral, CLING, expr.typeSuffix);
+    }
     else if expr is UnaryExpr {
         if wrap {
             w.push("(");

--- a/compiler/modules/front.syntax/parseExpr.bal
+++ b/compiler/modules/front.syntax/parseExpr.bal
@@ -221,6 +221,11 @@ function startPrimaryExpr(Tokenizer tok) returns Expr|err:Syntax {
         check tok.advance();
         return expr;
     }
+    else if t is [DECIMAL_FP_NUMBER, string, FLOAT_TYPE_SUFFIX|()] {
+        FpLiteralExpr expr = { untypedLiteral: t[1], typeSuffix: t[2], pos: tok.currentPos() };
+        check tok.advance();
+        return expr;
+    }
     else if t is [HEX_INT_LITERAL, string] {
         IntLiteralExpr expr = { base: 16, digits: t[1], pos: tok.currentPos() };
         check tok.advance();

--- a/compiler/modules/front.syntax/tests/data/V-stmt-foreach-trailing-dot-canon.bal
+++ b/compiler/modules/front.syntax/tests/data/V-stmt-foreach-trailing-dot-canon.bal
@@ -1,0 +1,11 @@
+function wrapper(boolean b) {
+    // @case
+    foreach int i in 0 ..< 1 {
+        foo(i);
+    }
+    // @end
+}
+
+
+function foo(int a) {
+}

--- a/compiler/modules/front.syntax/tests/data/V-stmt-foreach-trailing-dot.bal
+++ b/compiler/modules/front.syntax/tests/data/V-stmt-foreach-trailing-dot.bal
@@ -1,0 +1,11 @@
+function wrapper(boolean b) {
+    // @case
+    foreach int i in 0..<1 {
+        foo(i);
+    }
+    // @end
+}
+
+
+function foo(int a) {
+}

--- a/compiler/modules/types/core.bal
+++ b/compiler/modules/types/core.bal
@@ -674,7 +674,7 @@ function simpleMapMemberType(SemType t, MappingAtomicType[] mappingDefs) returns
 }
 
 public type Value readonly & record {|
-    string|int|boolean|() value;
+    string|int|float|boolean|() value;
 |};
 
 // If the type contains exactly onr shape, return a value
@@ -704,12 +704,15 @@ public function singleShape(SemType t) returns Value? {
     return ();
 }
 
-public function singleton(string|int|boolean|() v) returns SemType {
+public function singleton(string|int|float|boolean|() v) returns SemType {
     if v is () {
         return NIL;
     }
     else if v is int {
         return intConst(v);
+    }
+    else if v is float {
+        return floatConst(v);
     }
     else if v is string {
         return stringConst(v);
@@ -730,12 +733,15 @@ public function isReadOnly(SemType t) returns boolean {
     return (bits & UT_RW_MASK) == 0;
 }
 
-public function containsConst(SemType t, string|int|boolean|() v) returns boolean {
+public function containsConst(SemType t, string|int|float|boolean|() v) returns boolean {
     if v is () {
         return containsNil(t);
     }
     else if v is int {
         return containsConstInt(t, v);
+    }
+    else if v is float {
+        return containsConstFloat(t, v);
     }
     else if v is string {
         return containsConstString(t, v);
@@ -770,6 +776,15 @@ public function containsConstInt(SemType t, int n) returns boolean {
     }
     else {
         return intSubtypeContains(t.getSubtypeData(UT_INT), n);
+    }
+}
+
+public function containsConstFloat(SemType t, float n) returns boolean {
+    if t is UniformTypeBitSet {
+        return (t & (1 << UT_FLOAT)) != 0;
+    }
+    else {
+        return floatSubtypeContains(t.getSubtypeData(UT_FLOAT), n);
     }
 }
 

--- a/compiler/modules/types/float.bal
+++ b/compiler/modules/types/float.bal
@@ -10,6 +10,15 @@ public function floatConst(float value) returns SemType {
     return uniformSubtype(UT_FLOAT, st);
 }
 
+// XXX should this be generified and moved to enumerable? 
+function floatSubtypeContains(SubtypeData d, float f) returns boolean {
+    if d is boolean {
+        return d;
+    }
+    FloatSubtype v = <FloatSubtype>d;
+    return v.values.indexOf(f) != () ? v.allowed : !v.allowed;
+}
+
 function floatSubtypeUnion(SubtypeData d1, SubtypeData d2) returns SubtypeData {
     float[] values = [];
     boolean allowed = enumerableSubtypeUnion(<FloatSubtype>d1, <FloatSubtype>d2, values);

--- a/compiler/testSuite/Ofloat00.bal
+++ b/compiler/testSuite/Ofloat00.bal
@@ -1,0 +1,4 @@
+type f float;
+
+public function main() {
+}

--- a/compiler/testSuite/UVfloat00.bal
+++ b/compiler/testSuite/UVfloat00.bal
@@ -1,0 +1,3 @@
+public function main() {
+    any f = 0.0;
+}

--- a/compiler/testSuite/UVfloat01.bal
+++ b/compiler/testSuite/UVfloat01.bal
@@ -1,0 +1,5 @@
+public function main() {
+}
+
+function foo(float f) {
+}

--- a/compiler/testSuite/UVmatch00.bal
+++ b/compiler/testSuite/UVmatch00.bal
@@ -1,0 +1,15 @@
+import ballerina/io;
+
+public function main() {
+}
+
+function foo(any v) {
+    match v {
+        0.0 => {
+            io:println("zero");
+        }
+        _ => {
+            io:println("non-zero");
+        }
+    }
+}

--- a/compiler/tests/data/float-singleton2.bal
+++ b/compiler/tests/data/float-singleton2.bal
@@ -1,0 +1,21 @@
+// ALSO_NAN<:Float
+// ALSO_NAN<:NAN
+// INFINITY<:Float
+// NAN<:ALSO_NAN
+// NAN<:Float
+// NEGATIVE_INFINITY<:Float
+// NegativeZero<:Float
+// NegativeZero<:Zero
+// Zero<:Float
+// Zero<:NegativeZero
+
+// JBUG this is highlighted as an error
+const INFINITY = 1.0/0.0;
+const NEGATIVE_INFINITY = -1.0/0.0;
+const NAN = 0f/0f;
+const ALSO_NAN = -NAN;
+
+type Zero 0.0;
+type NegativeZero -0.0;
+
+type Float float;


### PR DESCRIPTION
Part of #294

I didn't put `t:singleShape` since I wasn't sure how to test with what is currently implemented.