### PR TITLE
Mark test ll files as generated for better Github stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/ll/*.ll linguist-generated=true


### PR DESCRIPTION
Mark test ll files as generated for better Github stats.
Currently GitHub shows this repo is mostly written in LLVM IR, not in Ballerina.