### PR TITLE
Build libbacktrace with runtime

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -5,8 +5,9 @@ LLC ?= llc$(LLVM_SUFFIX)
 OPT ?= opt$(LLVM_SUFFIX)
 export LLVM_LINK ?= llvm-link$(LLVM_SUFFIX)
 VALGRIND ?= valgrind
-OBJS=alloc.o error.o list.o main.o mapping.o panic.o print.o string.o int.o third-party/dtoa/emyg_dtoa.o tagged_inline.o
+CWARNINGS=-W -Wall -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -Wold-style-definition -Wmissing-format-attribute -Wcast-qual
 LIBBACKTRACE_OBJS=atomic.o dwarf.o fileline.o posix.o sort.o state.o backtrace.o simple.o elf.o mmapio.o mmap.o
+OBJS=alloc.o error.o list.o main.o mapping.o panic.o print.o string.o int.o third-party/dtoa/emyg_dtoa.o tagged_inline.o $(addprefix third-party/libbacktrace/, $(LIBBACKTRACE_OBJS))
 C_BCS=eq_inline.bc int_inline.bc list_inline.bc mapping_inline.bc string_inline.bc float_inline.bc
 LL_BCS=float_ir_inline.bc tagged_inline.bc
 BCS=$(C_BCS) $(LL_BCS)
@@ -26,18 +27,17 @@ test: all
 testCoverage: $(LIB) $(BCLIB)
 	$(MAKE) -C tests testCoverage
 
-$(LIB): $(LIBBACKTRACE_OBJS) $(OBJS)
+$(LIB): $(OBJS)
 	$(AR) r $@ $^
-
-$(LIBBACKTRACE_OBJS):
-	$(MAKE) -C third-party/libbacktrace all
-	$(AR) x third-party/libbacktrace/libbacktrace.a
 
 $(BCLIB): $(BCS)
 	set -o pipefail; \
 	$(LLVM_LINK) -o - -S $^ | \
 	sed -e '/define .*@_[Bb][a-zA-Z]/s/^define /define linkonce_odr /' -e '/target datalayout/ s/"$$/-ni:1"/' | \
 	$(LLVM_AS) >$@ 
+
+$(filter third-party/libbacktrace/%.o, $(OBJS)): third-party/libbacktrace/%.o: third-party/libbacktrace/%.c
+	$(CLANG) -DHAVE_CONFIG_H -funwind-tables -frandom-seed=$< $(CWARNINGS) -g -O2 -c -o $@ $<
 
 %.o: %.bc
 	$(CLANG) -O2 -c -o $@ $<
@@ -67,9 +67,8 @@ $(LL_BCS): %.bc: %.ll
 $(OBJS) $(BCS): $(INCLUDES)
 
 clean:
-	-rm -f $(OBJS) $(BCS) $(LIB) $(BCLIB) $(LIBBACKTRACE_OBJS)
+	-rm -f $(OBJS) $(BCS) $(LIB) $(BCLIB)
 	$(MAKE) -C tests clean
-	$(MAKE) -C third-party/libbacktrace clean
 
 .PHONY: test all
 # Ensure bogus files get deleted when there's an error

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -6,6 +6,7 @@ OPT ?= opt$(LLVM_SUFFIX)
 export LLVM_LINK ?= llvm-link$(LLVM_SUFFIX)
 VALGRIND ?= valgrind
 OBJS=alloc.o error.o list.o main.o mapping.o panic.o print.o string.o int.o third-party/dtoa/emyg_dtoa.o tagged_inline.o
+LIBBACKTRACE_OBJS=atomic.o dwarf.o fileline.o posix.o sort.o state.o backtrace.o simple.o elf.o mmapio.o mmap.o
 C_BCS=eq_inline.bc int_inline.bc list_inline.bc mapping_inline.bc string_inline.bc float_inline.bc
 LL_BCS=float_ir_inline.bc tagged_inline.bc
 BCS=$(C_BCS) $(LL_BCS)
@@ -25,8 +26,12 @@ test: all
 testCoverage: $(LIB) $(BCLIB)
 	$(MAKE) -C tests testCoverage
 
-$(LIB): $(OBJS)
+$(LIB): $(LIBBACKTRACE_OBJS) $(OBJS)
 	$(AR) r $@ $^
+
+$(LIBBACKTRACE_OBJS):
+	$(MAKE) -C third-party/libbacktrace all
+	$(AR) x third-party/libbacktrace/libbacktrace.a
 
 $(BCLIB): $(BCS)
 	set -o pipefail; \
@@ -62,8 +67,9 @@ $(LL_BCS): %.bc: %.ll
 $(OBJS) $(BCS): $(INCLUDES)
 
 clean:
-	-rm -f $(OBJS) $(BCS) $(LIB) $(BCLIB)
+	-rm -f $(OBJS) $(BCS) $(LIB) $(BCLIB) $(LIBBACKTRACE_OBJS)
 	$(MAKE) -C tests clean
+	$(MAKE) -C third-party/libbacktrace clean
 
 .PHONY: test all
 # Ensure bogus files get deleted when there's an error

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -5,9 +5,9 @@ LLC ?= llc$(LLVM_SUFFIX)
 OPT ?= opt$(LLVM_SUFFIX)
 export LLVM_LINK ?= llvm-link$(LLVM_SUFFIX)
 VALGRIND ?= valgrind
-CWARNINGS=-W -Wall -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -Wold-style-definition -Wmissing-format-attribute -Wcast-qual
-LIBBACKTRACE_OBJS=atomic.o dwarf.o fileline.o posix.o sort.o state.o backtrace.o simple.o elf.o mmapio.o mmap.o
-OBJS=alloc.o error.o list.o main.o mapping.o panic.o print.o string.o int.o third-party/dtoa/emyg_dtoa.o tagged_inline.o $(addprefix third-party/libbacktrace/, $(LIBBACKTRACE_OBJS))
+BT_WARN_FLAGS=-W -Wall -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -Wold-style-definition -Wmissing-format-attribute -Wcast-qual
+BT_OBJS=$(addprefix third-party/libbacktrace/, atomic.o dwarf.o fileline.o posix.o sort.o state.o backtrace.o simple.o elf.o mmapio.o mmap.o)
+OBJS=alloc.o error.o list.o main.o mapping.o panic.o print.o string.o int.o third-party/dtoa/emyg_dtoa.o tagged_inline.o $(BT_OBJS)
 C_BCS=eq_inline.bc int_inline.bc list_inline.bc mapping_inline.bc string_inline.bc float_inline.bc
 LL_BCS=float_ir_inline.bc tagged_inline.bc
 BCS=$(C_BCS) $(LL_BCS)
@@ -36,8 +36,8 @@ $(BCLIB): $(BCS)
 	sed -e '/define .*@_[Bb][a-zA-Z]/s/^define /define linkonce_odr /' -e '/target datalayout/ s/"$$/-ni:1"/' | \
 	$(LLVM_AS) >$@ 
 
-$(filter third-party/libbacktrace/%.o, $(OBJS)): third-party/libbacktrace/%.o: third-party/libbacktrace/%.c
-	$(CLANG) -DHAVE_CONFIG_H -funwind-tables -frandom-seed=$< $(CWARNINGS) -g -O2 -c -o $@ $<
+$(BT_OBJS): %.o: %.c
+	$(CLANG) -DHAVE_CONFIG_H -funwind-tables -frandom-seed=$< $(BT_WARN_FLAGS) -g -O2 -c -o $@ $<
 
 %.o: %.bc
 	$(CLANG) -O2 -c -o $@ $<

--- a/runtime/third-party/libbacktrace/config.h
+++ b/runtime/third-party/libbacktrace/config.h
@@ -2,7 +2,11 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
 /* ELF size: 32 or 64 */
+#ifdef __linux__
 #define BACKTRACE_ELF_SIZE 64
+#elif __APPLE__
+#define BACKTRACE_ELF_SIZE unused
+#endif
 
 /* XCOFF size: 32 or 64 */
 #define BACKTRACE_XCOFF_SIZE unused
@@ -25,7 +29,9 @@
 #define HAVE_DLFCN_H 1
 
 /* Define if dl_iterate_phdr is available. */
+#ifdef __linux__
 #define HAVE_DL_ITERATE_PHDR 1
+#endif
 
 /* Define to 1 if you have the fcntl function */
 #define HAVE_FCNTL 1
@@ -51,7 +57,9 @@
 #define HAVE_LIBLZMA 1
 
 /* Define to 1 if you have the <link.h> header file. */
+#ifdef __linux__
 #define HAVE_LINK_H 1
+#endif
 
 /* Define if AIX loadquery is available. */
 /* #undef HAVE_LOADQUERY */
@@ -60,7 +68,9 @@
 #define HAVE_LSTAT 1
 
 /* Define to 1 if you have the <mach-o/dyld.h> header file. */
-/* #undef HAVE_MACH_O_DYLD_H */
+#ifdef __APPLE__
+#define HAVE_MACH_O_DYLD_H 1
+#endif
 
 /* Define to 1 if you have the <memory.h> header file. */
 #define HAVE_MEMORY_H 1

--- a/runtime/third-party/libbacktrace/config.h
+++ b/runtime/third-party/libbacktrace/config.h
@@ -1,6 +1,18 @@
 /* config.h.  Generated from config.h.in by configure.  */
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
+#ifndef __APPLE__
+#ifndef __linux__
+#error Unsupported platform: only Linux and OS X supported for now
+#endif
+#endif
+
+#ifdef __APPLE__
+#ifndef __MACH__
+#error Unsupported platform: APPLE but not MACH
+#endif
+#endif
+
 /* ELF size: 32 or 64 */
 #ifdef __linux__
 #define BACKTRACE_ELF_SIZE 64


### PR DESCRIPTION
## Purpose
Fixes #390

This PR add seperate Makefile for libbacktrace and it will create necessary object files. Then runtime Makefile is changed to archive this object files into balrt.a