### PR TITLE
Stop re-running java in balt tests when unchanged

### DIFF
--- a/test/runcheck.sh
+++ b/test/runcheck.sh
@@ -9,8 +9,10 @@ if test ! -f "$1"; then
 fi
 b=`basename "$1"` 
 kind=`echo "$b" | head -c 1`
-out="out/actual/$b.txt"
-mkdir -p out/actual
+dir=`dirname "$1"`
+parent=`dirname $dir`
+out="$parent/actual/$b.txt"
+mkdir -p "$parent/actual"
 if test $kind == P; then
     $("./$1" >/dev/null 2>"$out")
 else

--- a/test/sub.mk
+++ b/test/sub.mk
@@ -16,16 +16,23 @@ diff_files = $(addsuffix .diff, $(addprefix result/, $(basename $(notdir $(ll_fi
 test: all
 	$(MAKE) -f ../../sub.mk tdir=$(tdir) testll
 
-all: ../../../compiler/testSuite/$(tdir).balt
+all:
+	if test $(COMPILER_JAR) -nt compile.stamp; then rm -f compile.stamp; fi
+	$(MAKE) -f ../../sub.mk tdir=$(tdir) compile
+
+compile: compile.stamp
+
+compile.stamp: ../../../compiler/testSuite/$(tdir).balt
 	-rm -fr llnew
 	-rm -fr expectnew
-	$(JAVA) -jar $(COMPILER_JAR) --outDir llnew --expectOutDir expectnew $?
+	$(JAVA) -jar $(COMPILER_JAR) --outDir llnew --expectOutDir expectnew $^
 	mkdir -p ll
 	mkdir -p expect
 	-../../update.sh expectnew expect txt
 	-../../update.sh llnew ll ll
 	-rm -fr llnew
 	-rm -fr expectnew
+	@touch $@
 
 testll: fail.txt
 	@echo testll

--- a/test/update.sh
+++ b/test/update.sh
@@ -18,8 +18,8 @@ fi
 for f in *.$ext; do
     existing="$to/${f:0:6}*.$ext"
     if test -f $existing; then
-        cmp -s $f $existing || mv -v $f $existing
+        cmp -s $f $existing || mv $f $existing
     else
-        mv -v $f $to
+        mv $f $to
     fi
 done


### PR DESCRIPTION
Stop re-running java in balt tests when tests are unchanged.
Remove logs on file copy (too noisy).
Correct the location of the `actual` dir