### PR TITLE
Add `make diff` and improve `make update`

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -13,9 +13,20 @@ clean:
 	-rm -fr out
 
 update:
+	mkdir -p out
+	find out -path "*/ll/*.ll" | sed -e 's;/ll/;/;' -e 's;^out;ll;' | sort > out/ll_curr.txt
+	find ll -type f | sort > out/ll_prev.txt
+	comm -13 out/ll_curr.txt out/ll_prev.txt | xargs rm -fv
+	rm out/ll_curr.txt out/ll_prev.txt
 	for f in out/*/ll/*.ll; do \
 		ll=`echo $$f | sed -e 's;/ll/;/;' -e 's;^out;ll;'`; \
 		cmp -s $$f $$ll || (mkdir -p `dirname $$ll` && cp -p $$f $$ll); \
 	done
 
-.PHONY: $(TARGETS) $(TDIRS) clean update
+diff: out/cmpll/ll_curr.txt out/cmpll/ll_prev.txt
+	@for f in out/*/ll/*.ll; do \
+		ll=`echo $$f | sed -e 's;/ll/;/;' -e 's;^out;ll;'`; \
+		[ -e $$ll ] && cmp -s $$f $$ll || echo $$f; \
+	done
+
+.PHONY: $(TARGETS) $(TDIRS) clean update diff

--- a/test/diff.sh
+++ b/test/diff.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-for f in out/*/ll/*.ll
-do
-    diff -u $f $(echo $f | sed -e 's;/ll/;/;' -e 's;^out;ll;')
-done


### PR DESCRIPTION
An example output of `make diff`:

```
> ll/01-ifelse/2-v.ll
< out/01-int/ll/add3-v.ll
out/cmpll/01-function/1-v.diff
```

`make update` is improved to remove files that are no longer in `out/*/ll`

Fixes #430
