### PR TITLE
Flip meaning of tagged int's 62th bit to immediate

### DIFF
--- a/compiler/testSuite/01-misc/equal-v.bal
+++ b/compiler/testSuite/01-misc/equal-v.bal
@@ -5,6 +5,12 @@ public function main() {
     io:println(mkNil() === mkNil()); // @output true
     io:println(mkInt(1) !== mkInt(1)); // @output false
     io:println(mkBoolean(true) === mkBoolean(true)); // @output true
+
+    // following are the boundaries of immediate vs heap int
+    io:println(mkInt(-36028797018963969) === mkInt(-36028797018963969)); // @output true
+    io:println(mkInt(-36028797018963968) === mkInt(-36028797018963968)); // @output true
+    io:println(mkInt(36028797018963967) === mkInt(36028797018963967)); // @output true
+    io:println(mkInt(36028797018963968) === mkInt(36028797018963968)); // @output true
 }
 
 function mkNil() returns any {

--- a/runtime/balrt.h
+++ b/runtime/balrt.h
@@ -16,7 +16,6 @@
 
 #define POINTER_MASK ((1L << TAG_SHIFT) - 1)
 
-#define FLAG_INT_ON_HEAP 0x20
 #define IMMEDIATE_FLAG (((uint64_t)0x20) << TAG_SHIFT)
 
 #define STRING_LARGE_FLAG 1
@@ -239,9 +238,8 @@ static READNONE inline UntypedPtr taggedToPtr(TaggedPtr p) {
 }
 
 static READONLY inline int64_t taggedToInt(TaggedPtr p) {
-    int t = getTag(p);
-    if (likely(t & FLAG_INT_ON_HEAP) == 0) {
-        uint64_t n = taggedPtrBits(p);
+    uint64_t n = taggedPtrBits(p);
+    if (likely((n & IMMEDIATE_FLAG) != 0)) {
         n &= POINTER_MASK;
         // sign extend
         n <<= 8;
@@ -399,7 +397,7 @@ static READONLY inline bool taggedPtrEqual(TaggedPtr tp1, TaggedPtr tp2) {
     switch (tag1) {
         case TAG_STRING:
             return taggedStringEqual(tp1, tp2);
-        case (TAG_INT|FLAG_INT_ON_HEAP):
+        case TAG_INT:
             {
                 IntPtr p1 = taggedToPtr(tp1);
                 IntPtr p2 = taggedToPtr(tp2);

--- a/runtime/eq_inline.c
+++ b/runtime/eq_inline.c
@@ -17,7 +17,7 @@ bool READONLY _bal_exact_eq(TaggedPtr tp1, TaggedPtr tp2) {
     switch (tag1) {
         case TAG_STRING:
             return taggedStringEqual(tp1, tp2);
-        case (TAG_INT|FLAG_INT_ON_HEAP):
+        case TAG_INT:
             {
                 IntPtr p1 = taggedToPtr(tp1);
                 IntPtr p2 = taggedToPtr(tp2);

--- a/runtime/int_inline.c
+++ b/runtime/int_inline.c
@@ -8,12 +8,12 @@
 
 TaggedPtr _bal_int_to_tagged(int64_t n) {
     if (likely(n >= IMMEDIATE_INT_MIN & n <= IMMEDIATE_INT_MAX)) {
-        return bitsToTaggedPtr(IMMEDIATE_INT_TRUNCATE(n) | (((uint64_t)TAG_INT) << TAG_SHIFT));
+        return bitsToTaggedPtr(IMMEDIATE_INT_TRUNCATE(n) | IMMEDIATE_FLAG | (((uint64_t)TAG_INT) << TAG_SHIFT));
     }
     else {
         GC int64_t *p = _bal_alloc(sizeof(int64_t));
         *p = n;
-        return ptrAddShiftedTag(p, ((uint64_t)TAG_INT|FLAG_INT_ON_HEAP) << TAG_SHIFT);
+        return ptrAddShiftedTag(p, ((uint64_t)TAG_INT) << TAG_SHIFT);
     }
 }
 

--- a/runtime/list.c
+++ b/runtime/list.c
@@ -13,7 +13,7 @@ static bool getFiller(ListDesc desc, TaggedPtr *valuePtr) {
             *valuePtr = bitsToTaggedPtr(((uint64_t)TAG_BOOLEAN) << TAG_SHIFT);
             return true;
         case (1 << TAG_INT):
-            *valuePtr = bitsToTaggedPtr(((uint64_t)TAG_INT) << TAG_SHIFT);
+            *valuePtr = bitsToTaggedPtr(IMMEDIATE_FLAG | ((uint64_t)TAG_INT) << TAG_SHIFT);
             return true;
         case (1 << TAG_FLOAT):
             {

--- a/runtime/tests/tagged_ptr.c
+++ b/runtime/tests/tagged_ptr.c
@@ -45,7 +45,7 @@ void testTaggedToInt() {
     // int on stack
     for(int64_t i=0; i <= NTESTS; i ++) {
         int64_t val = rand();
-        TaggedPtr ptr = bitsToTaggedPtr(val);
+        TaggedPtr ptr = bitsToTaggedPtr(val | IMMEDIATE_FLAG);
         int64_t prtVal = taggedToInt(ptr); //? work only with positive values
         assert(prtVal == val);
     }
@@ -56,7 +56,6 @@ void testTaggedToInt() {
 	int expectedValue = rand();
         *val = expectedValue;
         uint64_t addr = (uint64_t) val;
-        addr = addr | ((uint64_t)FLAG_INT_ON_HEAP << TAG_SHIFT);
         TaggedPtr ptr = bitsToTaggedPtr(addr);
         uint64_t ptrVal = taggedToInt(ptr);
         assert(ptrVal == expectedValue);


### PR DESCRIPTION
`taggedInt & 0x20000000 != 0` used to mean that the int is on heap, with this change it to mean that it's not on the heap, ie immediate.

Fixes #302