### PR TITLE
Add tests for imported consts

### DIFF
--- a/compiler/modules/front/front.bal
+++ b/compiler/modules/front/front.bal
@@ -173,9 +173,12 @@ function importPartPrefixes(ScannedModule scanned, (ModuleExports|string?)[] res
             resolved = i < resolvedImports.length() ? resolvedImports[i] : ();
         }
         foreach var decl in importsById[i].imports {
-            if resolved is string? {
-                err:Message msg = resolved == () ? `unsupported module ${moduleIdToString(moduleId)}` : resolved;
+            if resolved == () {
+                err:Message msg = `unsupported module ${moduleIdToString(moduleId)}`;
                 return err:unimplemented(msg, loc=err:location(files[decl.partIndex], decl.pos));
+            }
+            else if resolved is string {
+                return err:semantic(resolved, loc=err:location(files[decl.partIndex], decl.pos));
             }
             else {
                 string? declPrefix = decl.prefix;
@@ -204,7 +207,7 @@ function validEntryPoint(ModuleDefns mod) returns err:Any? {
 function addModulePart(ModuleDefns mod, s:ModulePart part) returns err:Semantic? {
     foreach s:ModuleLevelDefn defn in part.defns {
         if mod.hasKey(defn.name) {
-            return err:semantic(`duplicate definition if ${defn.name}`, s:defnLocation(defn));
+            return err:semantic(`duplicate definition in ${defn.name}`, s:defnLocation(defn));
         }
         mod.add(defn);
     }

--- a/compiler/modules/front/symbols.bal
+++ b/compiler/modules/front/symbols.bal
@@ -105,5 +105,5 @@ function lookupImportedConst(ModuleSymbols mod, s:ModuleLevelDefn modDefn, strin
     if defn is s:ResolvedConst {
         return defn[1];
     }
-    return err:semantic(`${prefix + ":" + varName} is not defined as a const`, loc=s:locationInDefn(modDefn), functionName=modDefn.name);
+    return err:semantic(`${prefix + ":" + varName} is not defined as a public const`, loc=s:locationInDefn(modDefn), functionName=modDefn.name);
 }

--- a/compiler/testSuite/08-import/const2-v.bal
+++ b/compiler/testSuite/08-import/const2-v.bal
@@ -1,0 +1,5 @@
+import root.level1;
+import ballerina/io;
+public function main() {
+    io:println(level1:A); // @output 44
+}

--- a/compiler/testSuite/08-import/const2-v.modules/level1/first.bal
+++ b/compiler/testSuite/08-import/const2-v.modules/level1/first.bal
@@ -1,0 +1,3 @@
+import root.level2;
+
+public const A = level2:B;

--- a/compiler/testSuite/08-import/const2-v.modules/level2/second.bal
+++ b/compiler/testSuite/08-import/const2-v.modules/level2/second.bal
@@ -1,0 +1,3 @@
+import root.level3;
+
+public const B = level3:C;

--- a/compiler/testSuite/08-import/const2-v.modules/level3/third.bal
+++ b/compiler/testSuite/08-import/const2-v.modules/level3/third.bal
@@ -1,0 +1,1 @@
+public const C = 44;

--- a/compiler/testSuite/08-import/const3-e.bal
+++ b/compiler/testSuite/08-import/const3-e.bal
@@ -1,0 +1,5 @@
+import root.selfref;
+
+public function main() {
+    int i = selfref:A;
+}

--- a/compiler/testSuite/08-import/const3-e.modules/selfref/self.bal
+++ b/compiler/testSuite/08-import/const3-e.modules/selfref/self.bal
@@ -1,0 +1,4 @@
+import root.selfref; // @error
+
+public const A = 1;
+const B = selfref:A;

--- a/compiler/testSuite/08-import/const4-e.bal
+++ b/compiler/testSuite/08-import/const4-e.bal
@@ -1,0 +1,5 @@
+import root.cycle1;
+
+const X = cycle1:A;
+public function main() {
+}

--- a/compiler/testSuite/08-import/const4-e.modules/cycle1/first.bal
+++ b/compiler/testSuite/08-import/const4-e.modules/cycle1/first.bal
@@ -1,0 +1,3 @@
+import root.cycle2;
+
+public const A = cycle2:B;

--- a/compiler/testSuite/08-import/const4-e.modules/cycle2/second.bal
+++ b/compiler/testSuite/08-import/const4-e.modules/cycle2/second.bal
@@ -1,0 +1,3 @@
+import root.cycle3;
+
+public const B = cycle3:C;

--- a/compiler/testSuite/08-import/const4-e.modules/cycle3/third.bal
+++ b/compiler/testSuite/08-import/const4-e.modules/cycle3/third.bal
@@ -1,0 +1,3 @@
+import root.cycle1; // @error
+
+public const C = cycle1:A;

--- a/compiler/testSuite/08-import/const5-e.bal
+++ b/compiler/testSuite/08-import/const5-e.bal
@@ -1,0 +1,5 @@
+import root.child1;
+
+const X = child1:A;
+public function main() {
+}

--- a/compiler/testSuite/08-import/const5-e.modules/child1/first-a.bal
+++ b/compiler/testSuite/08-import/const5-e.modules/child1/first-a.bal
@@ -1,0 +1,3 @@
+import root.child2;
+
+public const UNUSED = child2:B;

--- a/compiler/testSuite/08-import/const5-e.modules/child1/first-b.bal
+++ b/compiler/testSuite/08-import/const5-e.modules/child1/first-b.bal
@@ -1,0 +1,3 @@
+// imports are per file, not per module
+
+public const A = child2:B; // @error

--- a/compiler/testSuite/08-import/const5-e.modules/child2/second.bal
+++ b/compiler/testSuite/08-import/const5-e.modules/child2/second.bal
@@ -1,0 +1,1 @@
+public const B = 24;

--- a/compiler/testSuite/08-import/const6-e.bal
+++ b/compiler/testSuite/08-import/const6-e.bal
@@ -1,0 +1,5 @@
+import root.dupdef;
+
+public function main() {
+    int i = dupdef:CONST;
+}

--- a/compiler/testSuite/08-import/const6-e.modules/dupdef/a.bal
+++ b/compiler/testSuite/08-import/const6-e.modules/dupdef/a.bal
@@ -1,0 +1,1 @@
+public const CONST = 1;

--- a/compiler/testSuite/08-import/const6-e.modules/dupdef/b.bal
+++ b/compiler/testSuite/08-import/const6-e.modules/dupdef/b.bal
@@ -1,0 +1,1 @@
+public const CONST = 1; // @error

--- a/compiler/testSuite/future/langlib3-ue.bal
+++ b/compiler/testSuite/future/langlib3-ue.bal
@@ -1,0 +1,8 @@
+// @productions list-constructor-expr local-var-decl-stmt
+public function main() {
+    any x = [];
+    int n = x.length(); // @error
+    ignore(n); 
+}
+
+function ignore(int n) { }

--- a/compiler/tests/testSuite.bal
+++ b/compiler/tests/testSuite.bal
@@ -40,6 +40,9 @@ function testCompileEU(string path, string kind) returns file:Error|io:Error? {
             string base = check file:basename(path);
             boolean isE = kind[0] == "e";
             if isE {
+                if err is err:Unimplemented {
+                    io:println(err);
+                }
                 test:assertFalse(err is err:Unimplemented, "unimplemented error on E test" + path);
             }
             // io:println U errors are reported as semantic errors


### PR DESCRIPTION
- Add tests for imported consts.
- Fix `import cycle` being incorrectly reported as an `Unimplemented` error.
- Fix error messages.

Part of #473