### PR TITLE
Add failing test case for #490

### DIFF
--- a/compiler/testSuite/future/importcconst-fe.bal
+++ b/compiler/testSuite/future/importcconst-fe.bal
@@ -1,0 +1,5 @@
+import root.cycle;
+
+const X = cycle:Y;
+public function main() {
+}

--- a/compiler/testSuite/future/importcconst-fe.modules/cycle/short-cycle.bal
+++ b/compiler/testSuite/future/importcconst-fe.modules/cycle/short-cycle.bal
@@ -1,0 +1,3 @@
+import root; // @error
+
+const Y = root:X;


### PR DESCRIPTION
Currently gives `error: unsupported module 'root'` should give `error: import cycle` instead.