### PR TITLE
Rework named struct type

### DIFF
--- a/compiler/modules/print.llvm/common.bal
+++ b/compiler/modules/print.llvm/common.bal
@@ -38,9 +38,14 @@ public function arrayType(Type ty, int elementCount) returns ArrayType {
 }
 
 // Corresponds to llvm::StructType
-public type StructType readonly & record {
+public type StructType UnnamedStructType|NamedStructType;
+
+public type UnnamedStructType readonly & record {
     Type[] elementTypes;
-    string? name = ();
+};
+
+public type NamedStructType readonly & record {
+    string name;
 };
 
 public function structType(Type[] elementTypes) returns StructType {


### PR DESCRIPTION
## Purpose
Currently we actually have two different kinds of struct types

1. Those created using `structType` function (These don't have a name and their element types can't be changed after creation) 
2. Those created used `structCreateNamed` function in context (These have a name and their element types can be changed after creation)

In addition to differences in how we create them they are different based on how we output them. 1st type always inline all the element types where as second one only uses the name. While current implementation of `StructType` is sufficient to deal with requirements of type 1, requirements of type 2 is achieved using the Context (This is because we need `StructType` itself to be read-only  so we can't change the element types after creation). Context keep track of element types (So for the 2nd type `elementTypes` array is meaningless) and whenever we need the element types we get them via the context. In addition to keeping track of element types context also keep track of whether a given named struct type is used or not (To make sure only used types will end up in the output).

This implicit separation of `StructType` inside the llvm module leads to various unclear subtleties that can be avoided by explicitly spiting the `StructType` (While maintaining all the public interfaces as `StructType` such that users don't need to know the internal implementation)

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.