### PR TITLE
 Fix re-narrow inside loop bugs

### DIFF
--- a/compiler/modules/front.syntax/parseStmt.bal
+++ b/compiler/modules/front.syntax/parseStmt.bal
@@ -148,13 +148,13 @@ function finishIdentifierStmt(Tokenizer tok, string name1, Position startPos, Po
         name = name1;
         prefix = ();
     }
-    Token? cur = tok.current();
-    if cur == "(" {
+    if tok.current() == "(" {
         FunctionCallExpr expr = check finishFunctionCallExpr(tok, prefix, name, startPos);
         return finishCallStmt(tok, expr, startPos);
     }
     Position endPos = tok.previousEndPos();
     LExpr lExpr = { startPos, endPos, name, qNamePos: startPos, prefix };
+    Token? cur = tok.current();
     while true {
         Position opPos = tok.currentStartPos();
         if cur == "." {

--- a/compiler/modules/front.syntax/preparse.bal
+++ b/compiler/modules/front.syntax/preparse.bal
@@ -16,16 +16,16 @@ final readonly & map<CLOSE_BRACKET> closeBracketMap = {
 // (implying that the statement is a local variable declaration rather than a method call).
 // This is a preparse: the statement will be parsed again according to the value returned.
 function preparseParenTypeDesc(Tokenizer tok) returns boolean|err:Syntax {
-    boolean? result = check preparseBracketed(tok, ")");
-    if result != () {
-        return result;
+    boolean? parenResult = check preparseBracketed(tok, ")");
+    if parenResult != () {
+        return parenResult;
     }
     Token? t = tok.current();
     while t == "[" {
         check tok.advance();
-        result = check preparseBracketed(tok, "]");
-        if result != () {
-            return result;
+        boolean? squareResult = check preparseBracketed(tok, "]");
+        if squareResult != () {
+            return squareResult;
         }
         t = tok.current();
     }


### PR DESCRIPTION
nightly build fails with
```
ERROR [parseStmt.bal:(178:9,178:29)] invalid attempt to assign a value to a variable narrowed outside the loop
ERROR [preparse.bal:(26:9,26:52)] invalid attempt to assign a value to a variable narrowed outside the loop
```

This fixes it.