### PR TITLE
Rework list repr

### DIFF
--- a/compiler/modules/nback/build.bal
+++ b/compiler/modules/nback/build.bal
@@ -160,6 +160,26 @@ function buildErrorForPackedPanic(llvm:Builder builder, Scaffold scaffold, llvm:
     return err;
 }
 
+function buildStoreRepr(llvm:Builder builder, Scaffold scaffold, llvm:Value value, bir:Register reg, Repr sourceRepr) {
+    match sourceRepr.base {
+        BASE_REPR_INT => {
+            buildStoreInt(builder, scaffold, value, reg);
+        }
+        BASE_REPR_FLOAT => {
+            buildStoreFloat(builder, scaffold, value, reg);
+        }
+        BASE_REPR_BOOLEAN => {
+            buildStoreBoolean(builder, scaffold, value, reg);
+        }
+        BASE_REPR_TAGGED => {
+            buildStoreTagged(builder, scaffold, value, reg);
+        }
+        _ => {
+            panic err:impossible("unreached in buildStoreRepr");
+        }
+    }
+}
+
 function buildStoreInt(llvm:Builder builder, Scaffold scaffold, llvm:Value value, bir:Register reg) {
     builder.store(scaffold.getRepr(reg).base == BASE_REPR_TAGGED ? buildTaggedInt(builder, scaffold, value) : value,
                   scaffold.address(reg));

--- a/compiler/modules/nback/scaffold.bal
+++ b/compiler/modules/nback/scaffold.bal
@@ -474,6 +474,8 @@ function padBytes(byte[] bytes, int headerSize) returns int {
 
 final FloatRepr REPR_FLOAT = { };
 final BooleanRepr REPR_BOOLEAN = { };
+final IntRepr REPR_INT = { alwaysInImmediateRange: false, constraints: () };
+final IntRepr REPR_BYTE = { alwaysInImmediateRange: true, constraints: { min: 0, max: 255, all: true } };
 
 final TaggedRepr REPR_NIL = { subtype: t:NIL, alwaysImmediate: true };
 final TaggedRepr REPR_LIST_RW = { subtype: t:LIST_RW, alwaysImmediate: false };


### PR DESCRIPTION
Split ListRepr in to compile time know and runtime time know information.
Improves generated code for non-exact case by picking the specific setter/getter (previously always picked tagged).
Done on top of #931.

