### PR TITLE
Revert "Clean up anomalous uses of tmp registers"

### DIFF
--- a/compiler/modules/bir/bir.bal
+++ b/compiler/modules/bir/bir.bal
@@ -137,8 +137,7 @@ public enum RegisterKind {
     VAR_REGISTER_KIND,
     FINAL_REGISTER_KIND,
     NARRROW_REGISTER_KIND,
-    TMP_REGISTER_KIND,
-    ASSIGN_TMP_REGISTER_KIND
+    TMP_REGISTER_KIND
 }
 
 public type RegisterBase record {|
@@ -151,8 +150,7 @@ public type RegisterBase record {|
     RegisterKind kind;
 |};
 
-public type Register TmpRegister|AssignTmpRegister|ParamRegister|VarRegister|FinalRegister|NarrowRegister;
-public type BindableRegister ParamRegister|FinalRegister|VarRegister|NarrowRegister;
+public type Register TmpRegister|ParamRegister|VarRegister|FinalRegister|NarrowRegister;
 public type DeclRegisterKind PARAM_REGISTER_KIND|VAR_REGISTER_KIND|FINAL_REGISTER_KIND;
 
 public type DeclRegister record {|
@@ -167,15 +165,8 @@ public type TmpRegister readonly & record {|
     TMP_REGISTER_KIND kind;
 |};
 
-public type AssignTmpRegister readonly & record {|
-    *RegisterBase;
-    ASSIGN_TMP_REGISTER_KIND kind;
-|};
-
 public type NarrowRegister readonly & record {|
     *RegisterBase;
-    // position of the register that was narrowed
-    Position prevPos;
     NARRROW_REGISTER_KIND kind;
 |};
 
@@ -206,10 +197,8 @@ public function createFinalRegister(FunctionCode code, SemType semType, string n
     return r;
 }
 
-public function createNarrrowRegister(FunctionCode code, SemType semType, Register prev, string? name = (), Position? pos = ()) returns NarrowRegister {
-    // for debug information we at least need the position
-    Position prevPos = prev is NarrowRegister ? prev.prevPos : <Position> prev.pos;
-    NarrowRegister r = { number: code.registers.length(), semType, name, pos, kind: NARRROW_REGISTER_KIND, prevPos };
+public function createNarrrowRegister(FunctionCode code, SemType semType, string? name = (), Position? pos = ()) returns NarrowRegister {
+    NarrowRegister r = { number: code.registers.length(), semType, name, pos, kind: NARRROW_REGISTER_KIND };
     code.registers.push(r);
     return r;
 }
@@ -222,12 +211,6 @@ public function createParamRegister(FunctionCode code, SemType semType, string n
 
 public function createTmpRegister(FunctionCode code, SemType semType, string? name = (), Position? pos = ()) returns TmpRegister {
     TmpRegister r = { number: code.registers.length(), semType, name, pos, kind: TMP_REGISTER_KIND };
-    code.registers.push(r);
-    return r;
-}
-
-public function createAssignTmpRegister(FunctionCode code, SemType semType, string? name = (), Position? pos = ()) returns AssignTmpRegister {
-    AssignTmpRegister r = { number: code.registers.length(), semType, name, pos, kind: ASSIGN_TMP_REGISTER_KIND };
     code.registers.push(r);
     return r;
 }
@@ -568,7 +551,7 @@ public type CallInsn readonly & record {|
 public type AssignInsn readonly & record {|
     *InsnBase;
     INSN_ASSIGN name = INSN_ASSIGN;
-    AssignTmpRegister|VarRegister|FinalRegister result;
+    TmpRegister|VarRegister|FinalRegister result;
     Operand operand;
 |};
 

--- a/compiler/modules/front/expr.bal
+++ b/compiler/modules/front/expr.bal
@@ -31,7 +31,7 @@ type ExprEffect record {|
 
 type Binding record {|
     string name;
-    bir:BindableRegister reg;
+    bir:Register reg;
     boolean isFinal;
     boolean used = false;
     Binding? prev;
@@ -110,12 +110,8 @@ class ExprContext {
         return bir:createTmpRegister(self.code, t, (), pos);
     }
 
-    function createAssignTmpRegister(bir:SemType t, Position? pos = ()) returns bir:AssignTmpRegister {
-        return bir:createAssignTmpRegister(self.code, t, (), pos);
-    }
-
-    function createNarrowRegister(bir:SemType t, bir:Register prev, Position? pos = ()) returns bir:NarrowRegister {
-        return bir:createNarrrowRegister(self.code, t, prev, (), pos);
+    function createNarrowRegister(bir:SemType t, Position? pos = ()) returns bir:NarrowRegister {
+        return bir:createNarrrowRegister(self.code, t, (), pos);
     }
 
     function createBasicBlock(string? name = ()) returns bir:BasicBlock {
@@ -315,7 +311,7 @@ function codeGenNilLiftResult(ExprContext cx, ExprEffect nonNilEffect, bir:Basic
         bir:Operand nonNilResult = nonNilEffect.result;
         bir:BasicBlock nonNilBlock = nonNilEffect.block;
 
-        bir:AssignTmpRegister result = cx.createAssignTmpRegister(t:union(operandSemType(cx.mod.tc, nonNilResult), t:NIL), pos);
+        bir:TmpRegister result = cx.createTmpRegister(t:union(operandSemType(cx.mod.tc, nonNilResult), t:NIL));
         bir:AssignInsn nilAssign = { result, operand: bir:NIL_OPERAND, pos };
         ifNilBlock.insns.push(nilAssign);
         bir:BranchInsn branchInsn = { dest: block.label, pos };
@@ -377,7 +373,7 @@ function codeGenNilLift(ExprContext cx, t:SemType? expected, s:Expr[] operands, 
             nextBlock = cx.createBasicBlock();
             bir:InsnRef testInsnRef = bir:lastInsnRef(currentBlock);
             t:SemType baseType = t:diff(operand.semType, t:NIL);
-            bir:NarrowRegister newOperand = cx.createNarrowRegister(baseType, operand);
+            bir:NarrowRegister newOperand = cx.createNarrowRegister(baseType);
             bir:CondNarrowInsn narrowToBase = {
                 result: newOperand,
                 operand,
@@ -699,7 +695,7 @@ function codeGenLogicalBinaryExpr(ExprContext cx, bir:BasicBlock bb, s:BinaryLog
                                                                                             : [intersectNarrowing, expandedUnionNarrowing];
     Narrowing[] ifTrue = combineNarrowings(lhsIfTrue, rhsIfTrue, ifTrueCombinator);
     Narrowing[] ifFalse = combineNarrowings(lhsIfFalse, rhsIfFalse, ifFalseCombinator);
-    bir:AssignTmpRegister result = cx.createAssignTmpRegister(t:BOOLEAN, pos);
+    bir:TmpRegister result = cx.createTmpRegister(t:BOOLEAN, pos);
     bir:AssignInsn lhsAssignInsn = { result, operand: lhs, pos };
     shortCircuitBlock.insns.push(lhsAssignInsn);
     bir:AssignInsn rhsAssignInsn = { result, operand: rhs, pos };

--- a/compiler/modules/front/stmt.bal
+++ b/compiler/modules/front/stmt.bal
@@ -77,8 +77,8 @@ class StmtContext {
         return bir:createFinalRegister(self.code, t, name, pos);
     }
 
-    function createNarrowRegister(bir:SemType t, bir:Register prev, string? name, Position? pos) returns bir:NarrowRegister {
-        return bir:createNarrrowRegister(self.code, t, prev, name, pos);
+    function createNarrowRegister(bir:SemType t, string? name, Position? pos) returns bir:NarrowRegister {
+        return bir:createNarrrowRegister(self.code, t, name, pos);
     }
 
     function createParamRegister(bir:SemType t, string name, Position pos) returns bir:ParamRegister {
@@ -790,7 +790,7 @@ function addNarrowings(StmtContext cx, bir:BasicBlock bb, Environment env, Narro
         if ty === t:NEVER {
             panic err:impossible("narrowed to never type");
         }
-        bir:NarrowRegister narrowed = cx.createNarrowRegister(ty, binding.reg, binding.name, pos);
+        bir:NarrowRegister narrowed = cx.createNarrowRegister(ty, binding.name, pos);
         bir:CondNarrowInsn insn = {
             result: narrowed,
             operand: binding.reg,
@@ -887,30 +887,33 @@ function codeGenAssignToVar(StmtContext cx, bir:BasicBlock startBlock, Environme
     return { block: nextBlock, assignments };
 }
 
-function lookupVarRefForAssign(StmtContext cx, Environment env, string varName, Position pos) returns CodeGenError|[bir:VarRegister, Assignment[]] {
+function lookupVarRefForAssign(StmtContext cx, Environment env, string varName, Position pos) returns CodeGenError|[bir:Register, Assignment[]] {
     Binding binding = check lookupVarRefBinding(cx, varName, env, pos);
     if binding.isFinal {
         return cx.semanticErr(`cannot assign to ${varName}`, pos);
     }
-    bir:VarRegister unnarrowedReg;
+    bir:Register unnarrowedReg;
     Assignment[] assignments;
     Binding? unnarrowedBinding = binding.unnarrowed;
     if unnarrowedBinding == () {
         // no narrowed binding in effect
-        unnarrowedReg = <bir:VarRegister>binding.reg; // assigning to final or param registers are semantic errors and assigning to narrow register is invalid
+        unnarrowedReg = binding.reg;
         assignments = [];
     }
     else {
         // invalidate the narrowed binding
         // and use the unnarrowed binding
-        unnarrowedReg = <bir:VarRegister>unnarrowedBinding.reg; // assigning to final or param registers are semantic errors and assigning to narrow register is invalid
+        unnarrowedReg = unnarrowedBinding.reg;
         assignments = [{ unnarrowedReg: unnarrowedReg.number, narrowedReg: binding.reg.number, pos }];
     }
     return [unnarrowedReg, assignments];
 }
 
-function codeGenAssign(StmtContext cx, Environment env, bir:BasicBlock block, bir:VarRegister|bir:FinalRegister result, s:Expr expr, t:SemType semType, Position pos) returns CodeGenError|bir:BasicBlock {
+function codeGenAssign(StmtContext cx, Environment env, bir:BasicBlock block, bir:Register result, s:Expr expr, t:SemType semType, Position pos) returns CodeGenError|bir:BasicBlock {
     var { result: operand, block: nextBlock } = check cx.codeGenExpr(block, env, semType, expr);
+    if result !is bir:TmpRegister|bir:VarRegister|bir:FinalRegister {
+        panic error("can't assign to param or narrowed registers");
+    }
     bir:AssignInsn insn = { pos, result, operand };
     nextBlock.insns.push(insn);
     return nextBlock;
@@ -1026,6 +1029,9 @@ function codeGenCompoundAssignToVar(StmtContext cx,
                                     Position pos) returns CodeGenError|StmtEffect {
     var [result, assignments] = check lookupVarRefForAssign(cx, env, lValue.name, pos);
     var { block: nextBlock, result: operand } = check codeGenCompoundableBinaryExpr(cx.exprContext(env), startBlock, op, pos, result, rexpr);
+    if result !is bir:TmpRegister|bir:VarRegister {
+        panic error("result must be a tmp or var register");
+    }
     bir:AssignInsn insn = { pos, result, operand };
     nextBlock.insns.push(insn);
     return { block: nextBlock, assignments };
@@ -1140,7 +1146,7 @@ function codeGenCheckingCond(StmtContext cx, bir:BasicBlock bb, bir:Register ope
     bir:BasicBlock errorBlock = cx.createBasicBlock();
     bir:CondBranchInsn condBranch = { operand: isError, ifTrue: errorBlock.label, ifFalse: okBlock.label, pos };
     bb.insns.push(condBranch);
-    bir:NarrowRegister errorReg = cx.createNarrowRegister(errorType, operand, (), pos);
+    bir:NarrowRegister errorReg = cx.createNarrowRegister(errorType, (), pos);
     bir:CondNarrowInsn narrowToError = {
         result: errorReg,
         operand,
@@ -1149,7 +1155,7 @@ function codeGenCheckingCond(StmtContext cx, bir:BasicBlock bb, bir:Register ope
     };
     errorBlock.insns.push(narrowToError);
     codeGenCheckingTerminator(errorBlock, checkingKeyword, errorReg, pos);
-    bir:NarrowRegister result = cx.createNarrowRegister(okType, operand, (), pos);
+    bir:NarrowRegister result = cx.createNarrowRegister(okType, (), pos);
     bir:CondNarrowInsn narrowToOk = {
         result,
         operand,
@@ -1169,24 +1175,7 @@ function codeGenExprForCond(StmtContext cx, bir:BasicBlock bb, Environment env, 
     }
     else if flags != 0 {
         bir:TmpRegister reg = cx.createTmpRegister(t:BOOLEAN);
-        bir:EqualityInsn insn;
-        // intersection of the types of the operands of === and !=== must not be disjoint
-        if value {
-            insn = {
-                op: "===",
-                pos: expr.startPos,
-                operands: [{ value, semType: t:singleton(cx.mod.tc, t:BOOLEAN) }, { value: true, semType: t:BOOLEAN}],
-                result: reg
-            };
-        }
-        else {
-            insn = {
-                op: "!==",
-                pos: expr.startPos,
-                operands: [{ value, semType: t:singleton(cx.mod.tc, t:BOOLEAN) }, { value: false, semType: t:BOOLEAN}],
-                result: reg
-            };
-        }
+        bir:AssignInsn insn = { result: reg, operand: { value, semType: t:BOOLEAN }, pos: expr.startPos };
         block.insns.push(insn);
         result = reg;
     }


### PR DESCRIPTION
Reverts ballerina-platform/nballerina#943

This isn't right yet.

Problem is we are not modelling narrowed registers right.  We can narrow both tmp registers (in nil folding) and declared registers.