### PR TITLE
Downgrade llvm to 12

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -17,11 +17,19 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: Set LLVM suffix (macOs)
-        if: runner.os == 'macOs'
-        # default is 12.0.0 but 12.0.1 is available on '$(brew --prefix llvm)/bin/clang'
+      - name: Cache brew for LLVM (macOS)
+        id: cache-llvm
+        if: runner.os == 'macOS'
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/Library/Caches/Homebrew/
+          key: brew-llvm
+      - name: Install LLVM (macOS)
+        if: runner.os == 'macOS'
         run: |
-          echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+          brew install llvm@12
+          echo "/usr/local/opt/llvm@12/bin" >> $GITHUB_PATH
           echo "LLVM_SUFFIX=" >> $GITHUB_ENV
       - name: Cache jBallerina
         id: cache-jbal


### PR DESCRIPTION
GitHub upgraded default MacOS llvm version to 13, temporary downgrading it until we test and upgrade to 13 (or 14, after Jul 11).