### PR TITLE
Sync with ballerina lang change

### DIFF
--- a/compiler/modules/front/resolveTypes.bal
+++ b/compiler/modules/front/resolveTypes.bal
@@ -161,7 +161,7 @@ function resolveTypeDesc(ModuleSymbols mod, s:ModuleLevelDefn modDefn, int depth
         if defn == () {
             t:ListDefinition d = new;
             td.defn = d;
-            t:SemType[] members = from var x in td.members select check resolveTypeDesc(mod, modDefn, depth + 1, x);
+            t:SemType[] members = check from var x in td.members select check resolveTypeDesc(mod, modDefn, depth + 1, x);
             t:SemType rest = t:NEVER;
             s:TypeDesc? restTd = td.rest;
             if restTd != () {
@@ -289,7 +289,7 @@ function resolveTypeDesc(ModuleSymbols mod, s:ModuleLevelDefn modDefn, int depth
             foreach var arg in td.params {
                 a.push(arg.td);
             }
-            t:SemType[] args = from var x in a select check resolveTypeDesc(mod, modDefn, depth + 1, x);
+            t:SemType[] args = check from var x in a select check resolveTypeDesc(mod, modDefn, depth + 1, x);
             s:TypeDesc? retTy = td.ret;
             t:SemType ret = retTy != () ? check resolveTypeDesc(mod, modDefn, depth + 1, retTy) : t:NIL;
             return d.define(env, t:tuple(env, ...args), ret);

--- a/compiler/tests/testBalt.bal
+++ b/compiler/tests/testBalt.bal
@@ -39,7 +39,7 @@ function testBalt(string baltName, int offset, BaltTestHeader header, string[] l
 }
 
 function parseBalts() returns TestCaseMap|error {
-    string[] files = from var entry in check file:readDir("testSuite")
+    string[] files = check from var entry in check file:readDir("testSuite")
             where basenameExtension(check file:basename(entry.absPath))[1] == ".balt"
             select entry.absPath;
 


### PR DESCRIPTION
## Purpose
> Sync with ballerina lang change where query result is an error when a clause complete abruptly
> Related PR https://github.com/ballerina-platform/ballerina-lang/pull/36647

## Goals

## Approach
> Used `check` expression for the error to be thrown to the nearest lexically enclosing failure handling statement.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.