### PR TITLE
Fix nightly - refactor int min/max to consts

### DIFF
--- a/compiler/modules/print.llvm/tests/exprBinaryDiv.bal
+++ b/compiler/modules/print.llvm/tests/exprBinaryDiv.bal
@@ -26,7 +26,7 @@ function exprBinaryDiv() returns Module {
 
     builder.positionAtEnd(bb7);
     Value R8 = builder.load(R3);
-    Value R9 = builder.iCmp("eq", R8, constInt("i64",-9223372036854775808));
+    Value R9 = builder.iCmp("eq", R8, constInt("i64", int:MIN_VALUE));
     builder.condBr(R9, bb10, bb14);
 
     builder.positionAtEnd(bb10);

--- a/compiler/modules/print.llvm/tests/exprBinaryRemainder.bal
+++ b/compiler/modules/print.llvm/tests/exprBinaryRemainder.bal
@@ -28,7 +28,7 @@ function exprBinaryRemainder() returns Module {
 
     builder.positionAtEnd(bb9);
     Value R10 = builder.load(R4);
-    Value R11 = builder.iCmp("eq", R10, constInt("i64",-9223372036854775808));
+    Value R11 = builder.iCmp("eq", R10, constInt("i64", int:MIN_VALUE));
     
     BasicBlock bb16 = foo.appendBasicBlock();
     BasicBlock bb12 = foo.appendBasicBlock();

--- a/compiler/modules/print.llvm/tests/stmtAssignLiteral.bal
+++ b/compiler/modules/print.llvm/tests/stmtAssignLiteral.bal
@@ -11,8 +11,8 @@ function stmtAssignLiteral() returns Module {
     builder.store(constInt("i64", 42), R1);
     builder.store(constInt("i64", 43), R1);
     builder.store(constInt("i64", 44), R1);
-    builder.store(constInt("i64", 9223372036854775807), R1);
-    builder.store(constInt("i64", -9223372036854775808), R1);
+    builder.store(constInt("i64", int:MAX_VALUE), R1);
+    builder.store(constInt("i64", int:MIN_VALUE), R1);
     builder.ret();
     return m;
 }

--- a/compiler/modules/print.llvm/tests/stmtDeclLiteral.bal
+++ b/compiler/modules/print.llvm/tests/stmtDeclLiteral.bal
@@ -15,8 +15,8 @@ function stmtDeclLiteral() returns Module {
     builder.store(constInt("i64", 42), R1);
     builder.store(constInt("i64", 43), R2);
     builder.store(constInt("i64", 44), R3);
-    builder.store(constInt("i64", 9223372036854775807), R4);
-    builder.store(constInt("i64", -9223372036854775808), R5);
+    builder.store(constInt("i64", int:MAX_VALUE), R4);
+    builder.store(constInt("i64", int:MIN_VALUE), R5);
     builder.ret();
     return m;
 }


### PR DESCRIPTION
Nightly jballerina doesn't allow `-9223372036854775808` anymore.

https://github.com/ballerina-platform/ballerina-spec/issues/902#issuecomment-975150745
https://github.com/ballerina-platform/ballerina-lang/issues/32577
