### PR TITLE
Refactor function signature and function definition

### DIFF
--- a/compiler/compile.bal
+++ b/compiler/compile.bal
@@ -23,7 +23,7 @@ type Emitter object {
    // Build and write the output to a file.
    function emitModule(bir:Module birMod) returns CompileError?;
    // Called after all calls to emitModule.
-   function finalize(t:Env env, map<bir:FunctionSignature> potentialEntryFuncs) returns CompileError?;
+   function finalize(t:Env env, map<t:FunctionSignature> potentialEntryFuncs) returns CompileError?;
 };
 
 class LlvmEmitter {
@@ -50,7 +50,7 @@ class LlvmEmitter {
         self.programModules.push({ id, typeUsage });
     }
 
-    function finalize(t:Env env, map<bir:FunctionSignature> potentialEntryFuncs) returns CompileError? {
+    function finalize(t:Env env, map<t:FunctionSignature> potentialEntryFuncs) returns CompileError? {
         LlvmModule initMod = check nback:buildInitModule(env, self.programModules.reverse(), potentialEntryFuncs);
         string? outputBasename = self.outputBasename;
         if outputBasename != () {
@@ -73,7 +73,7 @@ class BirEmitter {
         check io:fileWriteString(outputFilename(self.outputBasename, id.names.slice(1), ".bir"), bir);
     }
 
-    function finalize(t:Env env, map<bir:FunctionSignature> potentialEntryFuncs) returns CompileError? {
+    function finalize(t:Env env, map<t:FunctionSignature> potentialEntryFuncs) returns CompileError? {
     }
 }
 
@@ -182,10 +182,10 @@ function subModuleSuffix(bir:ModuleId id) returns string {
     return ".".'join(...id.names.slice(1));
 }
 
-function filterFuncs(front:ModuleExports defns) returns map<bir:FunctionSignature> {
-    map<bir:FunctionSignature> result = {};
+function filterFuncs(front:ModuleExports defns) returns map<t:FunctionSignature> {
+    map<t:FunctionSignature> result = {};
     foreach var [name, defn] in defns.entries() {
-        if defn is bir:FunctionSignature {
+        if defn is t:FunctionSignature {
             result[name] = defn;
         }
     }

--- a/compiler/modules/bir.sexpr/parse.bal
+++ b/compiler/modules/bir.sexpr/parse.bal
@@ -121,12 +121,12 @@ public function toModule(Module moduleSexpr, bir:ModuleId modId) returns bir:Mod
     bir:FunctionDefn[] funcDefns = [];
     map<t:FunctionSignature> internalFuncDecl = {};
     FunctionCode[] funcCodes = [];
-    foreach var [identifier, visibility, [_, [params, ret], [_, partIndex], [_, line, col], [_, ...registers], [_, ...blocks]]] in funcs { // JBUG: can't use { s: identifier }
+    foreach var [identifier, visibility, [_, [paramNames, [params, ret]], [_, partIndex], [_, line, col], [_, ...registers], [_, ...blocks]]] in funcs { // JBUG: can't use { s: identifier }
         readonly & t:SemType[] paramTypes = from var t in params select t:fromSexpr(env, atoms, t);
         t:FunctionSignature signature = { returnType: t:fromSexpr(env ,atoms, ret), paramTypes, restParamType: () };
         internalFuncDecl[identifier.s] = signature;
         funcDefns.push({ symbol: { isPublic: visibility is PublicVisibility , identifier: identifier.s },
-                         signature,
+                         decl: { signature, paramNames: paramNames.cloneReadOnly() },
                          partIndex: vFilesByName.get(partIndex.s).partIndex(),
                          position: createPosition(line, col) });
         funcCodes.push({ registers, blocks });

--- a/compiler/modules/bir.sexpr/parse.bal
+++ b/compiler/modules/bir.sexpr/parse.bal
@@ -121,11 +121,11 @@ public function toModule(Module moduleSexpr, bir:ModuleId modId) returns bir:Mod
     bir:FunctionDefn[] funcDefns = [];
     map<t:FunctionSignature> internalFuncDecl = {};
     FunctionCode[] funcCodes = [];
-    foreach var [identifier, visibility, [_, [paramNames, sig], [_, partIndex], [_, line, col], [_, ...registers], [_, ...blocks]]] in funcs { // JBUG: can't use { s: identifier }
+    foreach var [identifier, visibility, [_, sig, [_, partIndex], [_, line, col], [_, ...registers], [_, ...blocks]]] in funcs { // JBUG: can't use { s: identifier }
         t:FunctionSignature signature = toFunctionSignature(env, atoms, sig);
         internalFuncDecl[identifier.s] = signature;
         funcDefns.push({ symbol: { isPublic: visibility is PublicVisibility , identifier: identifier.s },
-                         decl: { signature, paramNames: paramNames.cloneReadOnly() },
+                         decl: signature,
                          partIndex: vFilesByName.get(partIndex.s).partIndex(),
                          position: createPosition(line, col) });
         funcCodes.push({ registers, blocks });

--- a/compiler/modules/bir.sexpr/parse.bal
+++ b/compiler/modules/bir.sexpr/parse.bal
@@ -146,13 +146,11 @@ public function toModule(Module moduleSexpr, bir:ModuleId modId) returns bir:Mod
     return mod;
 }
 
-// FIXME:
 function toFunctionSignature(t:Env env, t:AtomTable atoms, Signature sexpr) returns t:FunctionSignature {
     var [params, ret] = sexpr;
     return { returnType: t:fromSexpr(env, atoms, ret),
              paramTypes: from var p in params select t:fromSexpr(env, atoms, p),
-             restParamType: ()
-           };
+             restParamType: () };
 }
 
 function toFunctionCode(ParseContext pc, FunctionCode code) returns bir:FunctionCode {

--- a/compiler/modules/bir.sexpr/parse.bal
+++ b/compiler/modules/bir.sexpr/parse.bal
@@ -439,7 +439,7 @@ function toOperand(FuncParseContext pc, Operand operand) returns bir:Operand {
         ["function", var symbolSexpr] => {
             bir:Symbol symbol = symbolFromSexpr(<FunctionRef>symbolSexpr);
             t:FunctionSignature signature = lookupSignature(pc, symbol);
-            t:SemType semType =  t:semTypeFromSignature(pc.tc, signature);
+            t:SemType semType =  t:functionSemType(pc.tc, signature);
             return <bir:FunctionConstOperand>{ value: { symbol, signature, erasedSignature: signature }, semType };
         }
         ["float", var f] => {

--- a/compiler/modules/bir.sexpr/schema.bal
+++ b/compiler/modules/bir.sexpr/schema.bal
@@ -13,10 +13,9 @@ public type FileRef ["file", sexpr:String];
 public type Module [["atoms", [sexpr:String, ts:Atom]...], ["defns", Function...], ["decls", ModuleDecls...], ["files", File...]];
 public type ModuleId [sexpr:String, sexpr:String, sexpr:String...];
 public type Signature [ts:Type[], ts:Type];
-public type FuncDecl [sexpr:Symbol[], Signature];
-public type FuncDefn [sexpr:String, FunctionTag, Signature];
-public type ModuleDecls [ModuleId, FuncDefn...];
-public type Function [sexpr:String, FunctionVisibility, [FunctionTag, FuncDecl, FileRef, Position, [RegistersTag, Register...], [BlocksTag, Block...]]];
+public type FuncDecl [sexpr:String, FunctionTag, Signature];
+public type ModuleDecls [ModuleId, FuncDecl...];
+public type Function [sexpr:String, FunctionVisibility, [FunctionTag, Signature, FileRef, Position, [RegistersTag, Register...], [BlocksTag, Block...]]];
 public type Register [sexpr:Symbol, bir:DeclRegisterKind|bir:TMP_REGISTER_KIND|bir:ASSIGN_TMP_REGISTER_KIND , ts:Type]|
                      [sexpr:Symbol, bir:NARROW_REGISTER_KIND, ts:Type, sexpr:Symbol];
 public type BlockPanic readonly & (["no-panic"]|["on-panic", Label]);

--- a/compiler/modules/bir.sexpr/schema.bal
+++ b/compiler/modules/bir.sexpr/schema.bal
@@ -13,9 +13,10 @@ public type FileRef ["file", sexpr:String];
 public type Module [["atoms", [sexpr:String, ts:Atom]...], ["defns", Function...], ["decls", ModuleDecls...], ["files", File...]];
 public type ModuleId [sexpr:String, sexpr:String, sexpr:String...];
 public type Signature [ts:Type[], ts:Type];
-public type FuncDecl [sexpr:String, FunctionTag, Signature];
-public type ModuleDecls [ModuleId, FuncDecl...];
-public type Function [sexpr:String, FunctionVisibility, [FunctionTag, Signature, FileRef, Position, [RegistersTag, Register...], [BlocksTag, Block...]]];
+public type FuncDecl [sexpr:Symbol[], Signature];
+public type FuncDefn [sexpr:String, FunctionTag, Signature];
+public type ModuleDecls [ModuleId, FuncDefn...];
+public type Function [sexpr:String, FunctionVisibility, [FunctionTag, FuncDecl, FileRef, Position, [RegistersTag, Register...], [BlocksTag, Block...]]];
 public type Register [sexpr:Symbol, bir:DeclRegisterKind|bir:TMP_REGISTER_KIND|bir:ASSIGN_TMP_REGISTER_KIND , ts:Type]|
                      [sexpr:Symbol, bir:NARROW_REGISTER_KIND, ts:Type, sexpr:Symbol];
 public type BlockPanic readonly & (["no-panic"]|["on-panic", Label]);

--- a/compiler/modules/bir.sexpr/serialize.bal
+++ b/compiler/modules/bir.sexpr/serialize.bal
@@ -167,10 +167,10 @@ function fromOperand(FuncSerializeContext sc, bir:Operand op) returns Operand & 
     if op is bir:Register {
         return fromRegister(sc, op);
     }
-    if op is bir:FunctionConstOperand {
-        return ["function", fromFunctionRefAccum(sc, op.value)];
+    t:SingleValue|bir:FunctionRef value = op.value;
+    if value is bir:FunctionRef {
+        return ["function", fromFunctionRefAccum(sc, value)];
     }
-    t:SingleValue value = op.value;
     if value is string {
         return <sexpr:String>{ s: value };
     }

--- a/compiler/modules/bir.sexpr/serialize.bal
+++ b/compiler/modules/bir.sexpr/serialize.bal
@@ -41,7 +41,7 @@ public function fromModule(t:Context tc, bir:Module mod) returns Module|err:Sema
     [sexpr:String, ts:Atom][] atoms = from var [s, atom] in sc.atoms.entries() select [{ s }, atom];
     ModuleDecls[] decl = from var { id, funcs } in sc.decls
                          select [id, ...from var [name, sig] in funcs.entries()
-                                        select <FuncDecl>[{ s: name }, "function", sig]];
+                                        select <FuncDefn>[{ s: name }, "function", sig]];
     File[] files = from var f in mod.getPartFiles()
                    let string? dir = f.directory(), string name = f.filename()
                    select dir == () ? [{ s: basename(name) }, { s: name }] : [{ s: basename(name) }, { s: name }, { s: dir}];
@@ -57,9 +57,9 @@ function fromFunction(SerializeContext sc, bir:FunctionDefn defn, bir:FunctionCo
     sexpr:String name = { s: defn.symbol.identifier };
     FunctionVisibility access = defn.symbol.isPublic ? PUBLIC_VISIBILITY : MODULE_VISIBILITY;
     var [line, col] = file.lineColumn(defn.position);
-    return [name, access, ["function", fromSignature(fsc, defn.signature), ["file", { s: basename(file.filename()) }], ["loc", line, col],
-                              ["registers", ...from var r in registers select defnFromRegister(fsc, r)],
-                              ["blocks", ...from var b in blocks select fromBasicBlock(fsc, b, file)]]];
+    return [name, access, ["function", [defn.decl.paramNames, fromSignature(fsc, defn.decl.signature)], ["file", { s: basename(file.filename()) }], ["loc", line, col],
+                          ["registers", ...from var r in registers select defnFromRegister(fsc, r)],
+                          ["blocks", ...from var b in blocks select fromBasicBlock(fsc, b, file)]]];
 }
 
 function basename(string path) returns string {

--- a/compiler/modules/bir.sexpr/serialize.bal
+++ b/compiler/modules/bir.sexpr/serialize.bal
@@ -38,8 +38,7 @@ public function fromModule(t:Context tc, bir:Module mod) returns Module|err:Sema
         bir:File file = mod.getPartFile(defn.partIndex);
         funcSexprs.push(fromFunction(sc, defn, code, file));
     }
-    readonly & [sexpr:String, ts:Atom][] atoms = from var [s, atom] in sc.atoms.entries()
-                                                 select [{ s }, atom.cloneReadOnly()]; // JBUG: can't make atom readonly
+    [sexpr:String, ts:Atom][] atoms = from var [s, atom] in sc.atoms.entries() select [{ s }, atom];
     ModuleDecls[] decl = from var { id, funcs } in sc.decls
                          select [id, ...from var [name, sig] in funcs.entries()
                                         select <FuncDecl>[{ s: name }, "function", sig]];
@@ -213,7 +212,7 @@ function addGetModDecls(FuncSerializeContext sc, readonly & ModuleId id) returns
     return newDecl;
 }
 
-function fromSignature(FuncSerializeContext sc, bir:FunctionSignature sig) returns readonly & Signature {
+function fromSignature(FuncSerializeContext sc, t:FunctionSignature sig) returns readonly & Signature {
     readonly & ts:Type[] params = from var t in sig.paramTypes select fromType(sc, t).cloneReadOnly();
     readonly & ts:Type ret = fromType(sc, sig.returnType);
     return [params, ret];

--- a/compiler/modules/bir.sexpr/serialize.bal
+++ b/compiler/modules/bir.sexpr/serialize.bal
@@ -41,7 +41,7 @@ public function fromModule(t:Context tc, bir:Module mod) returns Module|err:Sema
     [sexpr:String, ts:Atom][] atoms = from var [s, atom] in sc.atoms.entries() select [{ s }, atom];
     ModuleDecls[] decl = from var { id, funcs } in sc.decls
                          select [id, ...from var [name, sig] in funcs.entries()
-                                        select <FuncDefn>[{ s: name }, "function", sig]];
+                                        select <FuncDecl>[{ s: name }, "function", sig]];
     File[] files = from var f in mod.getPartFiles()
                    let string? dir = f.directory(), string name = f.filename()
                    select dir == () ? [{ s: basename(name) }, { s: name }] : [{ s: basename(name) }, { s: name }, { s: dir}];
@@ -57,7 +57,7 @@ function fromFunction(SerializeContext sc, bir:FunctionDefn defn, bir:FunctionCo
     sexpr:String name = { s: defn.symbol.identifier };
     FunctionVisibility access = defn.symbol.isPublic ? PUBLIC_VISIBILITY : MODULE_VISIBILITY;
     var [line, col] = file.lineColumn(defn.position);
-    return [name, access, ["function", [defn.decl.paramNames, fromSignature(fsc, defn.decl.signature)], ["file", { s: basename(file.filename()) }], ["loc", line, col],
+    return [name, access, ["function", fromSignature(fsc, defn.decl), ["file", { s: basename(file.filename()) }], ["loc", line, col],
                           ["registers", ...from var r in registers select defnFromRegister(fsc, r)],
                           ["blocks", ...from var b in blocks select fromBasicBlock(fsc, b, file)]]];
 }

--- a/compiler/modules/bir/bir.bal
+++ b/compiler/modules/bir/bir.bal
@@ -85,10 +85,8 @@ public type FunctionCode record {|
     Region[] regions = [];
 |};
 
-public type FunctionDecl record {|
-    t:FunctionSignature signature;
-    string[] paramNames;
-|};
+# This is sufficient until we support named parameters and default values.
+public type FunctionDecl t:FunctionSignature;
 
 public type Region record {|
     Label entry;

--- a/compiler/modules/bir/bir.bal
+++ b/compiler/modules/bir/bir.bal
@@ -64,7 +64,6 @@ public type Symbol InternalSymbol|ExternalSymbol;
 
 public type FunctionRef readonly & record {|
     Symbol symbol;
-    // Should we have a FunctionDecl here? one problem is creating a functionRef from a function value (registers only have functionType)
     t:FunctionSignature erasedSignature;
     t:FunctionSignature signature;
 |};

--- a/compiler/modules/bir/bir.bal
+++ b/compiler/modules/bir/bir.bal
@@ -48,7 +48,8 @@ public type FunctionDefn readonly & record {|
     # Name within the module
     InternalSymbol symbol;
     # The signature of the function
-    FunctionSignature signature;
+    # TODO: change var name
+    t:FunctionSignature signature;
 
     # Index of source part in which the definition occurs
     int partIndex;
@@ -65,8 +66,9 @@ public type Symbol InternalSymbol|ExternalSymbol;
 
 public type FunctionRef readonly & record {|
     Symbol symbol;
-    FunctionSignature erasedSignature;
-    FunctionSignature signature;
+    // TODO: this needs a function Decl
+    t:FunctionSignature erasedSignature;
+    t:FunctionSignature signature;
 |};
 
 # A function's code is represented as a factored control flow graph.
@@ -86,16 +88,9 @@ public type FunctionCode record {|
     Region[] regions = [];
 |};
 
-# This represents the signature of a function definition.
-# We don't need to convert this to a `SemType` unless
-# the definition is converted to a function value,
-# by referencing the name of the function as a variable
-# reference.
-public type FunctionSignature readonly & record {|
-    SemType returnType;
-    SemType[] paramTypes;
-    # if non-nil, last member of paramTypes will be an array type whose member type is restParamType
-    SemType? restParamType = ();
+public type FunctionDecl record {|
+    t:FunctionSignature signature;
+    // TODO: add param names
 |};
 
 public type Region record {|

--- a/compiler/modules/bir/bir.bal
+++ b/compiler/modules/bir/bir.bal
@@ -47,9 +47,7 @@ public type FunctionDefn readonly & record {|
     *ModuleDefn;
     # Name within the module
     InternalSymbol symbol;
-    # The signature of the function
-    # TODO: change var name
-    t:FunctionSignature signature;
+    FunctionDecl decl;
 
     # Index of source part in which the definition occurs
     int partIndex;
@@ -66,7 +64,7 @@ public type Symbol InternalSymbol|ExternalSymbol;
 
 public type FunctionRef readonly & record {|
     Symbol symbol;
-    // TODO: this needs a function Decl
+    // Should we have a FunctionDecl here? one problem is creating a functionRef from a function value (registers only have functionType)
     t:FunctionSignature erasedSignature;
     t:FunctionSignature signature;
 |};
@@ -90,7 +88,7 @@ public type FunctionCode record {|
 
 public type FunctionDecl record {|
     t:FunctionSignature signature;
-    // TODO: add param names
+    string[] paramNames;
 |};
 
 public type Region record {|

--- a/compiler/modules/bir/bir.bal
+++ b/compiler/modules/bir/bir.bal
@@ -339,7 +339,10 @@ public type Insn
 
 public type Operand ConstOperand|Register;
 
-public type ConstOperand SingleValueConstOperand|FunctionConstOperand;
+public type ConstOperand readonly & record {|
+    t:SemType semType;
+    t:SingleValue|FunctionRef value;
+|};
 
 public type SingleValueConstOperand  readonly & record {|
     t:SemType semType;

--- a/compiler/modules/bir/verify.bal
+++ b/compiler/modules/bir/verify.bal
@@ -54,7 +54,7 @@ class VerifyContext {
         return d:location(self.mod.getPartFile(self.defn.partIndex), pos);
     }
 
-    function returnType() returns t:SemType => self.defn.decl.signature.returnType;
+    function returnType() returns t:SemType => self.defn.decl.returnType;
 
     function symbolToString(Symbol sym) returns string {
         return self.mod.symbolToString(self.defn.partIndex, sym);

--- a/compiler/modules/bir/verify.bal
+++ b/compiler/modules/bir/verify.bal
@@ -448,7 +448,8 @@ function verifyCall(VerifyContext vc, CallInsn insn) returns err:Internal? {
 }
 
 function verifyCallIndirect(VerifyContext vc, CallIndirectInsn insn) returns err:Internal? {
-    return verifyFunctionCallArgs(vc, t:signatureFromSemType(vc.typeContext(), insn.operands[0].semType).paramTypes, insn);
+    t:FunctionAtomicType atomic = <t:FunctionAtomicType>t:functionAtomicType(vc.typeContext(), insn.operands[0].semType);
+    return verifyFunctionCallArgs(vc, t:functionSignature(vc.typeContext(), atomic).paramTypes, insn);
 }
 
 function verifyFunctionCallArgs(VerifyContext vc, SemType[] paramTypes, CallIndirectInsn|CallInsn insn) returns err:Internal? {

--- a/compiler/modules/bir/verify.bal
+++ b/compiler/modules/bir/verify.bal
@@ -448,7 +448,7 @@ function verifyCall(VerifyContext vc, CallInsn insn) returns err:Internal? {
 }
 
 function verifyCallIndirect(VerifyContext vc, CallIndirectInsn insn) returns err:Internal? {
-    return verifyFunctionCallArgs(vc, t:deconstructFunctionType(vc.typeContext(), insn.operands[0].semType)[1], insn);
+    return verifyFunctionCallArgs(vc, t:signatureFromSemType(vc.typeContext(), insn.operands[0].semType).paramTypes, insn);
 }
 
 function verifyFunctionCallArgs(VerifyContext vc, SemType[] paramTypes, CallIndirectInsn|CallInsn insn) returns err:Internal? {

--- a/compiler/modules/bir/verify.bal
+++ b/compiler/modules/bir/verify.bal
@@ -54,7 +54,7 @@ class VerifyContext {
         return d:location(self.mod.getPartFile(self.defn.partIndex), pos);
     }
 
-    function returnType() returns t:SemType => self.defn.signature.returnType;
+    function returnType() returns t:SemType => self.defn.decl.signature.returnType;
 
     function symbolToString(Symbol sym) returns string {
         return self.mod.symbolToString(self.defn.partIndex, sym);

--- a/compiler/modules/front.syntax/ast.bal
+++ b/compiler/modules/front.syntax/ast.bal
@@ -1,5 +1,4 @@
 import wso2/nballerina.types as t;
-import wso2/nballerina.bir;
 import wso2/nballerina.comm.diagnostic as d;
 
 public type Position d:Position;
@@ -39,7 +38,7 @@ public type FunctionDefn record {|
     StmtBlock body;
     Position namePos;
     // This is filled in during analysis
-    bir:FunctionSignature? signature = ();
+    t:FunctionSignature? signature = ();
 |};
 
 public type FunctionParam record {|

--- a/compiler/modules/front.syntax/parseTypeDesc.bal
+++ b/compiler/modules/front.syntax/parseTypeDesc.bal
@@ -2,6 +2,10 @@
 import wso2/nballerina.comm.err;
 
 function parseTypeDesc(Tokenizer tok) returns TypeDesc|err:Syntax {
+    return parseUnion(tok);
+}
+
+function parseUnion(Tokenizer tok) returns TypeDesc|err:Syntax {
     Position startPos = tok.currentStartPos();
     TypeDesc td = check parseIntersection(tok);
     if tok.current() == "|" {

--- a/compiler/modules/front/expr.bal
+++ b/compiler/modules/front/expr.bal
@@ -1464,8 +1464,7 @@ function codeGenMethodCallExpr(ExprContext cx, bir:BasicBlock bb, s:MethodCallEx
 }
 
 function functionRefFromRegister(t:Context tc, bir:Register register) returns bir:FunctionRef {
-    // TODO: when we support type variance we will need to support t:FUNCTION here as well
-    t:FunctionSignature signature = functionSignature(tc, <t:ComplexSemType>register.semType);
+    t:FunctionSignature signature = t:signatureFromSemType(tc, register.semType);
     bir:InternalSymbol symbol = { isPublic: false, identifier: registerName(register) };
     return { symbol, signature, erasedSignature: signature };
 }
@@ -1478,12 +1477,6 @@ function registerName(bir:Register register) returns string {
         return registerName(register.underlying);
     }
     return <string>register.name;
-}
-
-// TODO: remove this
-function functionSignature(t:Context tc, t:ComplexSemType semType) returns t:FunctionSignature {
-    var [returnType, paramTypes, restParamType] = t:deconstructFunctionType(tc, semType);
-    return { paramTypes: paramTypes.cloneReadOnly(), returnType, restParamType };
 }
 
 function codeGenCall(ExprContext cx, bir:BasicBlock curBlock, bir:FunctionRef func, t:SemType returnType, bir:Operand[] args, Position pos) returns ExprEffect {

--- a/compiler/modules/front/expr.bal
+++ b/compiler/modules/front/expr.bal
@@ -1822,15 +1822,7 @@ function singletonBooleanOperand(t:Context tc, boolean value) returns bir:Boolea
 }
 
 function functionValOperand(t:Context tc, bir:FunctionRef value) returns bir:FunctionConstOperand {
-    return { value, semType: functionRefTy(tc, value) };
-}
-
-function functionRefTy(t:Context tc, bir:FunctionRef value) returns t:SemType {
-    t:Env env = tc.env;
-    t:FunctionDefinition defn = new(env);
-    var { paramTypes, restParamType, returnType } = value.signature;
-    t:SemType rest = restParamType is () ? t:NEVER : restParamType;
-    return defn.define(env, t:defineListTypeWrapped(new(), env, paramTypes, rest=rest, mut=t:CELL_MUT_NONE), returnType);
+    return { value, semType: t:semTypeFromSignature(tc, value.signature) };
 }
 
 function constifyRegister(bir:Register reg) returns bir:Operand {

--- a/compiler/modules/front/expr.bal
+++ b/compiler/modules/front/expr.bal
@@ -1464,7 +1464,8 @@ function codeGenMethodCallExpr(ExprContext cx, bir:BasicBlock bb, s:MethodCallEx
 }
 
 function functionRefFromRegister(t:Context tc, bir:Register register) returns bir:FunctionRef {
-    t:FunctionSignature signature = t:signatureFromSemType(tc, register.semType);
+    t:FunctionAtomicType atomic = <t:FunctionAtomicType>t:functionAtomicType(tc, register.semType);
+    t:FunctionSignature signature = t:functionSignature(tc, atomic);
     bir:InternalSymbol symbol = { isPublic: false, identifier: registerName(register) };
     return { symbol, signature, erasedSignature: signature };
 }
@@ -1822,7 +1823,7 @@ function singletonBooleanOperand(t:Context tc, boolean value) returns bir:Boolea
 }
 
 function functionValOperand(t:Context tc, bir:FunctionRef value) returns bir:FunctionConstOperand {
-    return { value, semType: t:semTypeFromSignature(tc, value.signature) };
+    return { value, semType: t:functionSemType(tc, value.signature) };
 }
 
 function constifyRegister(bir:Register reg) returns bir:Operand {

--- a/compiler/modules/front/front.bal
+++ b/compiler/modules/front/front.bal
@@ -28,10 +28,12 @@ class Module {
         foreach var defn in syms.defns {
             if defn is s:FunctionDefn {
                 self.functionDefnSource.push(defn);
+                readonly & string[] paramNames = from var param in defn.params where !param.isRest select param.name;
+                readonly & bir:FunctionDecl decl = { signature: <t:FunctionSignature>defn.signature, paramNames };
                 functionDefns.push({
                     symbol: <bir:InternalSymbol>{ identifier: defn.name, isPublic: defn.vis == "public" },
                     // casting away nil here, because it was filled in by `resolveTypes`
-                    signature: <t:FunctionSignature>defn.signature,
+                    decl,
                     position: defn.namePos,
                     partIndex: defn.part.partIndex
                 });
@@ -45,7 +47,7 @@ class Module {
     public function getTypeContext() returns t:Context => self.syms.tc;
 
     public function generateFunctionCode(int i) returns bir:FunctionCode|err:Semantic|err:Unimplemented {
-        return codeGenFunction(self.syms, self.functionDefnSource[i], self.functionDefns[i].signature);
+        return codeGenFunction(self.syms, self.functionDefnSource[i], self.functionDefns[i].decl.signature);
     }
    
     public function finish() returns err:Semantic? {

--- a/compiler/modules/front/front.bal
+++ b/compiler/modules/front/front.bal
@@ -29,7 +29,7 @@ class Module {
             if defn is s:FunctionDefn {
                 self.functionDefnSource.push(defn);
                 readonly & string[] paramNames = from var param in defn.params where !param.isRest select param.name;
-                readonly & bir:FunctionDecl decl = { signature: <t:FunctionSignature>defn.signature, paramNames };
+                readonly & bir:FunctionDecl decl = <t:FunctionSignature>defn.signature;
                 functionDefns.push({
                     symbol: <bir:InternalSymbol>{ identifier: defn.name, isPublic: defn.vis == "public" },
                     // casting away nil here, because it was filled in by `resolveTypes`
@@ -47,7 +47,7 @@ class Module {
     public function getTypeContext() returns t:Context => self.syms.tc;
 
     public function generateFunctionCode(int i) returns bir:FunctionCode|err:Semantic|err:Unimplemented {
-        return codeGenFunction(self.syms, self.functionDefnSource[i], self.functionDefns[i].decl.signature);
+        return codeGenFunction(self.syms, self.functionDefnSource[i], self.functionDefns[i].decl);
     }
    
     public function finish() returns err:Semantic? {

--- a/compiler/modules/front/front.bal
+++ b/compiler/modules/front/front.bal
@@ -28,11 +28,10 @@ class Module {
         foreach var defn in syms.defns {
             if defn is s:FunctionDefn {
                 self.functionDefnSource.push(defn);
-                readonly & bir:FunctionDecl decl = <t:FunctionSignature>defn.signature;
                 functionDefns.push({
                     symbol: <bir:InternalSymbol>{ identifier: defn.name, isPublic: defn.vis == "public" },
                     // casting away nil here, because it was filled in by `resolveTypes`
-                    decl,
+                    decl: <t:FunctionSignature>defn.signature,
                     position: defn.namePos,
                     partIndex: defn.part.partIndex
                 });

--- a/compiler/modules/front/front.bal
+++ b/compiler/modules/front/front.bal
@@ -28,7 +28,6 @@ class Module {
         foreach var defn in syms.defns {
             if defn is s:FunctionDefn {
                 self.functionDefnSource.push(defn);
-                readonly & string[] paramNames = from var param in defn.params where !param.isRest select param.name;
                 readonly & bir:FunctionDecl decl = <t:FunctionSignature>defn.signature;
                 functionDefns.push({
                     symbol: <bir:InternalSymbol>{ identifier: defn.name, isPublic: defn.vis == "public" },

--- a/compiler/modules/front/front.bal
+++ b/compiler/modules/front/front.bal
@@ -31,7 +31,7 @@ class Module {
                 functionDefns.push({
                     symbol: <bir:InternalSymbol>{ identifier: defn.name, isPublic: defn.vis == "public" },
                     // casting away nil here, because it was filled in by `resolveTypes`
-                    signature: <bir:FunctionSignature>defn.signature,
+                    signature: <t:FunctionSignature>defn.signature,
                     position: defn.namePos,
                     partIndex: defn.part.partIndex
                 });
@@ -214,7 +214,7 @@ function validEntryPoint(ModuleDefns mod) returns err:Diagnostic? {
         if defn.params.length() > 0 {
             return err:unimplemented(`parameters for ${"main"} not yet implemented`, s:defnLocation(defn));
         }
-        if t:intersect((<bir:FunctionSignature>defn.signature).returnType, t:ERROR) != t:NEVER {
+        if t:intersect((<t:FunctionSignature>defn.signature).returnType, t:ERROR) != t:NEVER {
             return err:unimplemented(`returning an error from ${"main"} function is not implemented`, s:defnLocation(defn));
         }
     }
@@ -235,7 +235,7 @@ function validInit(ModuleDefns defns) returns err:Diagnostic? {
 }
 
 function validInitReturnType(s:FunctionDefn defn) returns err:Semantic? {
-    t:SemType returnType = (<bir:FunctionSignature>defn.signature).returnType;
+    t:SemType returnType = (<t:FunctionSignature>defn.signature).returnType;
     if t:intersect(returnType, t:NIL) != t:NIL {
         return err:semantic(`return type of ${defn.name} function must allow nil`, s:defnLocation(defn));
     }

--- a/compiler/modules/front/lib.bal
+++ b/compiler/modules/front/lib.bal
@@ -1,4 +1,3 @@
-import wso2/nballerina.bir;
 import wso2/nballerina.types as t;
 
 type LangLibFunction [LangLibModuleName, string, readonly & t:SemType[], t:SemType];
@@ -13,7 +12,7 @@ final readonly & LangLibFunction[] langLibFunctions = [
     ["error", "message", [t:ERROR], t:STRING]
 ];
 
-function getLangLibFunction(string mod, string func) returns bir:FunctionSignature? {
+function getLangLibFunction(string mod, string func) returns t:FunctionSignature? {
     foreach var [moduleName, functionName, paramTypes, returnType] in langLibFunctions {
         if moduleName == mod && functionName == func {
             return { returnType, paramTypes };
@@ -22,7 +21,7 @@ function getLangLibFunction(string mod, string func) returns bir:FunctionSignatu
     return ();
 }
 
-final readonly & map<bir:FunctionSignature> ioLibFunctions = {
+final readonly & map<t:FunctionSignature> ioLibFunctions = {
     println: { paramTypes: [t:LIST], returnType: t:NIL, restParamType: t:VAL }
 };
 

--- a/compiler/modules/front/resolveTypes.bal
+++ b/compiler/modules/front/resolveTypes.bal
@@ -1,6 +1,5 @@
 import wso2/nballerina.types as t;
 import wso2/nballerina.front.syntax as s;
-import wso2/nballerina.bir;
 import wso2/nballerina.comm.err;
 import wso2/nballerina.comm.diagnostic as d;
 
@@ -74,7 +73,7 @@ function resolveDefn(ModuleSymbols mod, s:ModuleLevelDefn defn) returns ResolveT
     }
 }
 
-function resolveFunctionSignature(ModuleSymbols mod, s:FunctionDefn defn) returns bir:FunctionSignature|ResolveTypeError {
+function resolveFunctionSignature(ModuleSymbols mod, s:FunctionDefn defn) returns t:FunctionSignature|ResolveTypeError {
     // JBUG doing this as a from/select panics if resolveSubsetTypeDesc returns an error
     // e.g.10-intersect/never2-e.bal
     t:SemType[] paramTypes = [];

--- a/compiler/modules/front/resolveTypes.bal
+++ b/compiler/modules/front/resolveTypes.bal
@@ -317,7 +317,7 @@ function resolveTypeDesc(ModuleSymbols mod, s:ModuleLevelDefn modDefn, int depth
     if td is s:FunctionTypeDesc {
         t:FunctionDefinition? defn = td.defn;
         if defn == () {
-            t:FunctionDefinition d = new(env);
+            t:FunctionDefinition d = new;
             td.defn = d;
             s:TypeDesc[] a = [];
             t:SemType rest = t:NEVER;

--- a/compiler/modules/front/stmt.bal
+++ b/compiler/modules/front/stmt.bal
@@ -214,7 +214,7 @@ class StmtContext {
 
 }
 
-function codeGenFunction(ModuleSymbols mod, s:FunctionDefn defn, bir:FunctionSignature signature) returns bir:FunctionCode|CodeGenError {
+function codeGenFunction(ModuleSymbols mod, s:FunctionDefn defn, t:FunctionSignature signature) returns bir:FunctionCode|CodeGenError {
     StmtContext cx = new(mod, defn, signature.returnType);
     bir:BasicBlock startBlock = cx.createBasicBlock();
     BindingChain? bindings = ();

--- a/compiler/modules/front/symbols.bal
+++ b/compiler/modules/front/symbols.bal
@@ -32,7 +32,7 @@ type Import record {|
     boolean used = false;
 |};
 
-public type ExportedDefn bir:FunctionSignature|t:SemType|s:ResolvedConst;
+public type ExportedDefn t:FunctionSignature|t:SemType|s:ResolvedConst;
 
 public type ModuleExports readonly & map<ExportedDefn>;
 

--- a/compiler/modules/nback/basic.bal
+++ b/compiler/modules/nback/basic.bal
@@ -230,7 +230,8 @@ function buildCall(llvm:Builder builder, Scaffold scaffold, bir:CallInsn insn) r
 }
 
 function buildCallIndirect(llvm:Builder builder, Scaffold scaffold, bir:CallIndirectInsn insn) returns BuildError? {
-    t:FunctionSignature signature = t:signatureFromSemType(scaffold.typeContext(), insn.operands[0].semType);
+    t:FunctionAtomicType atomic = <t:FunctionAtomicType>t:functionAtomicType(scaffold.typeContext(), insn.operands[0].semType);
+    t:FunctionSignature signature = t:functionSignature(scaffold.typeContext(), atomic);
     llvm:Value[] args = check buildFunctionCallArgs(builder, scaffold, signature.paramTypes, signature.paramTypes, from int i in 1 ..< insn.operands.length() select insn.operands[i]);
     llvm:PointerType fnStructPtrTy = llvm:pointerType(llvm:structType([llvm:pointerType(buildFunctionSignature(signature))]));
     llvm:PointerValue fnStructTaggedPtr = <llvm:PointerValue>builder.load(scaffold.address(insn.operands[0]));

--- a/compiler/modules/nback/basic.bal
+++ b/compiler/modules/nback/basic.bal
@@ -214,7 +214,7 @@ function buildCall(llvm:Builder builder, Scaffold scaffold, bir:CallInsn insn) r
     bir:FunctionRef funcRef = insn.func;
     t:SemType[] paramTypes = funcRef.erasedSignature.paramTypes;
     t:SemType[] instantiatedParamTypes = funcRef.signature.paramTypes;
-    bir:FunctionSignature signature = funcRef.erasedSignature;
+    t:FunctionSignature signature = funcRef.erasedSignature;
     bir:Symbol funcSymbol = funcRef.symbol;
     llvm:Value[] args = check buildFunctionCallArgs(builder, scaffold, paramTypes, instantiatedParamTypes, insn.args);
     llvm:Function func;
@@ -231,7 +231,7 @@ function buildCall(llvm:Builder builder, Scaffold scaffold, bir:CallInsn insn) r
 
 function buildCallIndirect(llvm:Builder builder, Scaffold scaffold, bir:CallIndirectInsn insn) returns BuildError? {
     var [returnType, paramTypes, restParamType] = t:deconstructFunctionType(scaffold.typeContext(), insn.operands[0].semType);
-    bir:FunctionSignature signature = { returnType, paramTypes: paramTypes.cloneReadOnly(), restParamType };
+    t:FunctionSignature signature = { returnType, paramTypes: paramTypes.cloneReadOnly(), restParamType };
     llvm:Value[] args = check buildFunctionCallArgs(builder, scaffold, paramTypes, paramTypes, from int i in 1 ..< insn.operands.length() select insn.operands[i]);
     llvm:PointerType fnStructPtrTy = llvm:pointerType(llvm:structType([llvm:pointerType(buildFunctionSignature(signature))]));
     llvm:PointerValue fnStructTaggedPtr = <llvm:PointerValue>builder.load(scaffold.address(insn.operands[0]));
@@ -277,7 +277,7 @@ function buildStoreRet(llvm:Builder builder, Scaffold scaffold, RetRepr retRepr,
     }
 }
 
-function buildFunctionDecl(Scaffold scaffold, bir:ExternalSymbol symbol, bir:FunctionSignature sig) returns llvm:FunctionDecl|BuildError {
+function buildFunctionDecl(Scaffold scaffold, bir:ExternalSymbol symbol, t:FunctionSignature sig) returns llvm:FunctionDecl|BuildError {
     llvm:FunctionDecl? decl = scaffold.getImportedFunction(symbol);
     if decl != () {
         return decl;

--- a/compiler/modules/nback/build.bal
+++ b/compiler/modules/nback/build.bal
@@ -340,13 +340,13 @@ function buildReprValue(llvm:Builder builder, Scaffold scaffold, bir:Operand ope
     if operand is bir:Register {
         return buildLoad(builder, scaffold, operand);
     }
-    else if operand is bir:FunctionConstOperand {
-        TaggedRepr repr = { subtype: t:FUNCTION, alwaysImmediate: false };
-        return [repr, check buildFunctionConstValue(scaffold, operand)];
-    }
     else {
-        t:SingleValue value = operand.value;
-        if value is string {
+        t:SingleValue|bir:FunctionRef value = operand.value;
+        if value is bir:FunctionRef {
+            TaggedRepr repr = { subtype: t:FUNCTION, alwaysImmediate: false };
+            return [repr, check buildFunctionConstValue(scaffold, value)];
+        }
+        else if value is string {
             byte[] bytes = value.toBytes();
             int nBytes = bytes.length();
             boolean alwaysImmediate = isSmallString(value.length(), bytes, nBytes);
@@ -374,8 +374,8 @@ function buildReprValue(llvm:Builder builder, Scaffold scaffold, bir:Operand ope
     }
 }
 
-function buildFunctionConstValue(Scaffold scaffold, bir:FunctionConstOperand val) returns llvm:Value|BuildError {
-    var { symbol, signature } = val.value;
+function buildFunctionConstValue(Scaffold scaffold, bir:FunctionRef ref) returns llvm:Value|BuildError {
+    var { symbol, signature } = ref;
     llvm:Function func;
     if symbol is bir:InternalSymbol {
         func = scaffold.getFunctionDefn(symbol.identifier);

--- a/compiler/modules/nback/build.bal
+++ b/compiler/modules/nback/build.bal
@@ -431,7 +431,7 @@ function heapPointerType(llvm:Type ty) returns llvm:PointerType {
     return llvm:pointerType(ty, HEAP_ADDR_SPACE);
 }
 
-function buildFunctionSignature(bir:FunctionSignature signature) returns llvm:FunctionType {
+function buildFunctionSignature(t:FunctionSignature signature) returns llvm:FunctionType {
     llvm:Type[] paramTypes = from var ty in signature.paramTypes select (semTypeRepr(ty)).llvm;
     RetRepr repr = semTypeRetRepr(signature.returnType);
     llvm:FunctionType ty = {

--- a/compiler/modules/nback/init.bal
+++ b/compiler/modules/nback/init.bal
@@ -118,7 +118,7 @@ class InitModuleContext {
 
 };
 
-public function buildInitModule(t:Env env, ProgramModule[] modules, map<bir:FunctionSignature> publicFuncs) returns llvm:Module|BuildError {
+public function buildInitModule(t:Env env, ProgramModule[] modules, map<t:FunctionSignature> publicFuncs) returns llvm:Module|BuildError {
     llvm:Context llContext = new;
     llvm:Module llMod = llContext.createModule();
     buildInitTypes(llContext, llMod, env, modules);
@@ -127,7 +127,7 @@ public function buildInitModule(t:Env env, ProgramModule[] modules, map<bir:Func
     return llMod;
 }
 
-function buildMain(bir:ModuleId entryModId, string userMainName, bir:FunctionSignature? userMainSig, llvm:Module llMod, llvm:Builder builder) {
+function buildMain(bir:ModuleId entryModId, string userMainName, t:FunctionSignature? userMainSig, llvm:Module llMod, llvm:Builder builder) {
     llvm:FunctionType ty = { returnType: "void", paramTypes: [] };
     llvm:FunctionDefn func = llMod.addFunctionDefn("_bal_main", ty);
     builder.positionAtEnd(func.appendBasicBlock());

--- a/compiler/modules/nback/module.bal
+++ b/compiler/modules/nback/module.bal
@@ -18,7 +18,7 @@ public function buildModule(bir:Module birMod, *Options options) returns [llvm:M
     llvm:FunctionType[] llFuncTypes = [];
     map<llvm:FunctionDefn> llFuncMap = {};
     foreach var defn in functionDefns {
-        llvm:FunctionType ty = buildFunctionSignature(defn.decl.signature);
+        llvm:FunctionType ty = buildFunctionSignature(defn.decl);
         llFuncTypes.push(ty);
         bir:InternalSymbol symbol = defn.symbol;
         string mangledName = mangleInternalSymbol(modId, symbol);

--- a/compiler/modules/nback/module.bal
+++ b/compiler/modules/nback/module.bal
@@ -18,7 +18,7 @@ public function buildModule(bir:Module birMod, *Options options) returns [llvm:M
     llvm:FunctionType[] llFuncTypes = [];
     map<llvm:FunctionDefn> llFuncMap = {};
     foreach var defn in functionDefns {
-        llvm:FunctionType ty = buildFunctionSignature(defn.signature);
+        llvm:FunctionType ty = buildFunctionSignature(defn.decl.signature);
         llFuncTypes.push(ty);
         bir:InternalSymbol symbol = defn.symbol;
         string mangledName = mangleInternalSymbol(modId, symbol);

--- a/compiler/modules/nback/scaffold.bal
+++ b/compiler/modules/nback/scaffold.bal
@@ -171,9 +171,9 @@ class Scaffold {
         self.birBlocks = code.blocks;
         final Repr[] reprs = from var reg in code.registers select semTypeRepr(reg.semType);
         self.reprs = reprs;
-        self.returnType = defn.decl.signature.returnType;
+        self.returnType = defn.decl.returnType;
         self.retRepr = semTypeRetRepr(self.returnType);
-        self.nParams = defn.decl.signature.paramTypes.length();
+        self.nParams = defn.decl.paramTypes.length();
         llvm:BasicBlock entry = llFunc.appendBasicBlock();
 
         self.blocks = from var b in code.blocks select llFunc.appendBasicBlock(b.name);

--- a/compiler/modules/nback/scaffold.bal
+++ b/compiler/modules/nback/scaffold.bal
@@ -171,9 +171,9 @@ class Scaffold {
         self.birBlocks = code.blocks;
         final Repr[] reprs = from var reg in code.registers select semTypeRepr(reg.semType);
         self.reprs = reprs;
-        self.returnType = defn.signature.returnType;
+        self.returnType = defn.decl.signature.returnType;
         self.retRepr = semTypeRetRepr(self.returnType);
-        self.nParams = defn.signature.paramTypes.length();
+        self.nParams = defn.decl.signature.paramTypes.length();
         llvm:BasicBlock entry = llFunc.appendBasicBlock();
 
         self.blocks = from var b in code.blocks select llFunc.appendBasicBlock(b.name);

--- a/compiler/modules/nback/scaffold.bal
+++ b/compiler/modules/nback/scaffold.bal
@@ -256,7 +256,7 @@ class Scaffold {
         return newDefn;
     }
 
-    function getFunctionValue(llvm:Function func, bir:FunctionSignature signature, bir:Symbol symbol) returns llvm:ConstPointerValue {
+    function getFunctionValue(llvm:Function func, t:FunctionSignature signature, bir:Symbol symbol) returns llvm:ConstPointerValue {
         FunctionValueDefn? curDefn = self.mod.functionValueDefns[symbol];
         if curDefn != () {
             return curDefn.value;
@@ -608,7 +608,7 @@ function isIntConstrainedToImmediate(t:IntSubtypeConstraints? c) returns boolean
     return IMMEDIATE_INT_MIN <= c.min && c.max <= IMMEDIATE_INT_MAX;
 }
 
-function addFunctionValueDefn(llvm:Context context, llvm:Module mod, llvm:Function func, bir:FunctionSignature signature, int defnIndex) returns llvm:ConstPointerValue {
+function addFunctionValueDefn(llvm:Context context, llvm:Module mod, llvm:Function func, t:FunctionSignature signature, int defnIndex) returns llvm:ConstPointerValue {
     llvm:StructType ty = llvm:structType([llvm:pointerType(buildFunctionSignature(signature))]);
     llvm:ConstValue initValue = context.constStruct([func]);
     llvm:ConstPointerValue ptr = mod.addGlobal(ty,

--- a/compiler/modules/types.json/parse.bal
+++ b/compiler/modules/types.json/parse.bal
@@ -145,7 +145,7 @@ function parseCompoundType(t:Context tc, Binding? b, string k, json[] jlist, Pat
             if s != () {
                 return s;
             }
-            t:FunctionDefinition def = new(env);
+            t:FunctionDefinition def = new;
             t:SemType[] v = check parseTypes(tc, consDefBinding(jlist, def, b), jlist, parent, 1);
             if v.length() == 0 {
                 return t:FUNCTION;

--- a/compiler/modules/types/core.bal
+++ b/compiler/modules/types/core.bal
@@ -230,6 +230,11 @@ public type MappingFiller readonly & record {|
     SemType semType;
 |};
 
+type FunctionTypeMemo readonly & record {|
+    FunctionSignature signature;
+    SemType semType;
+|};
+
 // Used in testing types.regex to create context without a Module
 public function contextFromEnv(Env env) returns Context {
     return new(env);
@@ -253,6 +258,8 @@ public class Context {
     final table<ComparableMemo> key(semType1, semType2) comparableMemo = table [];
     final table<SingletonMemo> key(value) singletonMemo = table [];
     final table<FillerMemo> key(semType) fillerMemo = table [];
+    final table<FunctionTypeMemo> key(signature) functionAtomicTypeMemo = table [];
+    final table<FunctionTypeMemo> key(semType) functionSignatureMemo = table [];
 
     SemType? anydataMemo = ();
     SemType? jsonMemo = ();

--- a/compiler/modules/types/core.bal
+++ b/compiler/modules/types/core.bal
@@ -122,6 +122,15 @@ public isolated class Env {
         }
     }
 
+    isolated function functionAtomType(Atom atom) returns FunctionAtomicType {
+        if atom is RecAtom {
+            return self.getRecFunctionAtomType(atom);
+        }
+        else {
+            return <FunctionAtomicType>atom.atomicType;
+        }
+    }
+
     isolated function recListAtom() returns RecAtom {
         lock {
             int result = self.recListAtoms.length();
@@ -259,7 +268,6 @@ public class Context {
     final table<SingletonMemo> key(value) singletonMemo = table [];
     final table<FillerMemo> key(semType) fillerMemo = table [];
     final table<FunctionTypeMemo> key(signature) functionAtomicTypeMemo = table [];
-    final table<FunctionTypeMemo> key(semType) functionSignatureMemo = table [];
 
     SemType? anydataMemo = ();
     SemType? jsonMemo = ();

--- a/compiler/modules/types/core.bal
+++ b/compiler/modules/types/core.bal
@@ -26,7 +26,7 @@ type TypeAtom readonly & record {|
     AtomicType atomicType;
 |};
 
-type AtomicType ListAtomicType|MappingAtomicType|CellAtomicType;
+type AtomicType ListAtomicType|MappingAtomicType|CellAtomicType|FunctionAtomicType;
 
 
 // All the SemTypes used in any type operation (e.g. isSubtype) must have been created using the Env.
@@ -79,6 +79,10 @@ public isolated class Env {
     }
 
     isolated function mappingAtom(MappingAtomicType atomicType) returns TypeAtom {
+        return self.typeAtom(atomicType);
+    }
+
+    isolated function functionAtom(FunctionAtomicType atomicType) returns TypeAtom {
         return self.typeAtom(atomicType);
     }
 
@@ -277,7 +281,12 @@ public class Context {
     }
 
     function functionAtomType(Atom atom) returns FunctionAtomicType {
-        return self.env.getRecFunctionAtomType(<RecAtom>atom);
+        if atom is RecAtom {
+            return self.env.getRecFunctionAtomType(atom);
+        }
+        else {
+            return <FunctionAtomicType>atom.atomicType;
+        }
     }
 }
 

--- a/compiler/modules/types/function.bal
+++ b/compiler/modules/types/function.bal
@@ -25,6 +25,19 @@ public class FunctionDefinition {
     }    
 }
 
+# This represents the signature of a function definition.
+# We don't need to convert this to a `SemType` unless
+# the definition is converted to a function value,
+# by referencing the name of the function as a variable
+# reference.
+public type FunctionSignature readonly & record {|
+    SemType returnType;
+    SemType[] paramTypes;
+    # if non-nil, last member of paramTypes will be an array type whose member type is restParamType
+    SemType? restParamType = ();
+|};
+
+
 function functionSubtypeIsEmpty(Context cx, SubtypeData t) returns boolean {
     return memoSubtypeIsEmpty(cx, cx.functionMemo, functionBddIsEmpty, <Bdd>t);
 }
@@ -102,6 +115,7 @@ public function functionAtomicType(Context cx, SemType semType) returns Function
     return ();
 }
 
+// FIXME: replace this with a function SemType -> FunctionSignature
 public function deconstructFunctionType(Context cx, SemType semType) returns [SemType, SemType[], SemType?] {
     // This is not exactly correct since semType could be diff/union of function types
     // We need something to select a function inherent type similar to how `selectListInherentType` works

--- a/compiler/modules/types/function.bal
+++ b/compiler/modules/types/function.bal
@@ -42,16 +42,16 @@ public function signatureFromSemType(Context cx, SemType semType) returns Functi
     ListAtomicType listAtom = <ListAtomicType>listAtomicType(cx, argList);
     SemType[] paramTypes = from int i in 0 ..< listAtom.members.fixedLength select listAtomicTypeMemberAtInnerVal(listAtom, i);
     SemType restInnerVal = cellInnerVal(listAtom.rest);
-    SemType? restParamType;
-    if restInnerVal == NEVER {
-        restParamType = ();
-    }
-    else {
-        restParamType = restInnerVal;
-        // SemType arrTy = defineListTypeWrapped(new, cx.env, rest = restInnerVal, mut = CELL_MUT_NONE);
-        // paramTypes.push(arrTy);
-    }
+    SemType? restParamType = restInnerVal == NEVER ? () : listAtom.rest;
     return { returnType, paramTypes: paramTypes.cloneReadOnly(), restParamType };
+}
+
+public function semTypeFromSignature(Context cx, FunctionSignature signature) returns SemType {
+    Env env = cx.env;
+    FunctionDefinition defn = new(env);
+    var { paramTypes, restParamType, returnType } = signature;
+    SemType rest = restParamType is () ? NEVER : restParamType;
+    return defn.define(env, defineListTypeWrapped(new(), env, paramTypes, rest=rest, mut=CELL_MUT_NONE), returnType);
 }
 
 function functionSubtypeIsEmpty(Context cx, SubtypeData t) returns boolean {

--- a/compiler/modules/types/function.bal
+++ b/compiler/modules/types/function.bal
@@ -139,11 +139,7 @@ function functionTheta(Context cx, SemType t0, SemType t1, Conjunction? pos) ret
 }
 
 public function functionAtomicType(Context cx, SemType semType) returns FunctionAtomicType? {
-    if semType is BasicTypeBitSet {
-        // TODO: when supporting function type variance we will need to support t:FUNCTION
-        return ();
-    }
-    if !isSubtypeSimple(semType, FUNCTION) {
+    if !isSubtypeSimple(semType, FUNCTION) || semType is BasicTypeBitSet {
         return ();
     }
     return bddFunctionAtomicType(cx.env, <Bdd>getComplexSubtypeData(semType, BT_FUNCTION));
@@ -153,7 +149,7 @@ function bddFunctionAtomicType(Env env, Bdd bdd) returns FunctionAtomicType? {
     if bdd is boolean {
         return ();
     }
-    else if bdd.left == true && bdd.middle == false && bdd.right == false {
+    if bdd.left == true && bdd.middle == false && bdd.right == false {
         return env.functionAtomType(bdd.atom);
     }
     return ();

--- a/compiler/modules/types/sexprParse.bal
+++ b/compiler/modules/types/sexprParse.bal
@@ -207,7 +207,7 @@ function fromAtomSexpr(SexprAtomParseContext pc, string name, ts:Atom atomSexpr)
             return fromMappingSexpr(pc, name, <ts:Field[]>fieldsSexpr, rest);
         }
         ["function", var args, var ret] => {
-            FunctionDefinition d = new(pc.env);
+            FunctionDefinition d = new;
             pc.started[name] = d;
             ListDefinition listDef = new;
             SemType[] initial = from var member in <ts:Type[]>args select fromSexprInternal(pc, member);

--- a/compiler/modules/types/tests/coretest.bal
+++ b/compiler/modules/types/tests/coretest.bal
@@ -198,6 +198,20 @@ function funcTest4() {
 }
 
 @test:Config{}
+function funcExactTest() {
+    Env env = new;
+    SemType t1 = func(env, tupleTypeWrapped(env, INT, INT), INT);
+    SemType t2 = func(env, tupleTypeWrapped(env, INT, INT), INT);
+    test:assertEquals(t1, t2);
+    SemType t3 = func(env, tupleTypeWrapped(env), NEVER);
+    SemType t4 = func(env, tupleTypeWrapped(env), NEVER);
+    test:assertEquals(t3, t4);
+    SemType t5 = func(env, defineListTypeWrapped(new, env, rest = INT), INT);
+    SemType t6 = func(env, defineListTypeWrapped(new, env, rest = INT), INT);
+    test:assertEquals(t5, t6);
+}
+
+@test:Config{}
 function stringTest() {
     string [] result = [];
     enumerableListUnion(["a", "b", "d"], ["c"], result);

--- a/compiler/modules/types/tests/coretest.bal
+++ b/compiler/modules/types/tests/coretest.bal
@@ -156,7 +156,7 @@ function tupleTest4() {
 }
 
 function func(Env env, SemType args, SemType ret) returns SemType {
-    FunctionDefinition def = new(env);
+    FunctionDefinition def = new;
     return def.define(env, args, ret);  
 }
 

--- a/compiler/testSuite/semtype/func-rec-tv.bal
+++ b/compiler/testSuite/semtype/func-rec-tv.bal
@@ -1,0 +1,30 @@
+type F int | function(int) returns F;
+
+// @type F0 < F
+// @type F1 < F
+type F0 function(int) returns int;
+type F1 function(int) returns F0;
+
+type G int | function(G) returns int;
+
+// @type G0 < G
+// @type G1 <> G
+type G0 function(G) returns int;
+type G1 function(int) returns int;
+
+// @type GG0 < F
+type GG G | string;
+type GG0 function(GG) returns int;
+
+type H int | function(H) returns H;
+
+// @type H0 < H
+// @type H1 <> H
+// @type H2 < H
+type H0 function(H) returns int;
+type H1 function(int) returns int;
+type H2 function(H) returns H;
+
+// @type HH0 < H
+type HH H | string;
+type HH0 function(HH) returns int;

--- a/compiler/tests/testSuite.bal
+++ b/compiler/tests/testSuite.bal
@@ -306,7 +306,7 @@ class TestBirEmitter {
         test:assertEquals(firstRoundLl, secondRoundLl);
     }
 
-    function finalize(t:Env env, map<bir:FunctionSignature> potentialEntryFuncs) returns CompileError? {
+    function finalize(t:Env env, map<t:FunctionSignature> potentialEntryFuncs) returns CompileError? {
     }
 }
 

--- a/runtime/balrt.h
+++ b/runtime/balrt.h
@@ -346,6 +346,11 @@ typedef GC struct LargeString {
     char bytes[];
 } *LargeStringPtr;
 
+typedef void(*FunctionPtr)();
+typedef GC struct FunctionValue {
+    FunctionPtr funcPtr;
+} *FunctionValuePtr;
+
 // Roundup to multiple of 8
 static inline int roundUpInt(int n) {
     return (n + 7) & ~7;


### PR DESCRIPTION
## Purpose
+ Move `FunctionSignature` to the `types` module
+ Avoid creating unnecessary recursive atoms in `FunctionDefinition`
+ Introduce helper functions to translate between `FunctionSignature` and `SemType`

Related to #1193
