### PR TITLE
Rename type branch to type cond branch

### DIFF
--- a/compiler/modules/bir.sexpr/parse.bal
+++ b/compiler/modules/bir.sexpr/parse.bal
@@ -260,8 +260,8 @@ function toInsn(FuncParseContext pc, Insn insnSexpr, Position? posSexpr) returns
                 pos
             };
         }
-        ["type-branch", var operand, var ty, var ifTrue, var ifFalse, var ifTrueRegister, var ifFalseRegister] => {
-            return <bir:TypeBranchInsn>{
+        ["type-cond-branch", var operand, var ty, var ifTrue, var ifFalse, var ifTrueRegister, var ifFalseRegister] => {
+            return <bir:TypeCondBranchInsn>{
                 operand: lookupRegister(pc, <sexpr:Symbol>operand),
                 semType: toSemType(pc, <ts:Type>ty),
                 ifTrue: lookupLabel(pc, <string>ifTrue),

--- a/compiler/modules/bir.sexpr/schema.bal
+++ b/compiler/modules/bir.sexpr/schema.bal
@@ -37,10 +37,10 @@ public type MapEntry readonly & [sexpr:String, Operand];
 public type TypeMergePred readonly & [Label, Operand];
 
 public type Insn ResultInsn|OperandInsn|Unimpl|
-                 CallInsn|CallGenericInsn|TypeBranchInsn|BranchInsn|TypeCastInsn|TypeTestInsn|CondBranchInsn|MappingConstructInsn|ListConstructInsn|TypeMergeInsn|ListGetInsn;
+                 CallInsn|CallGenericInsn|TypeCondBranchInsn|BranchInsn|TypeCastInsn|TypeTestInsn|CondBranchInsn|MappingConstructInsn|ListConstructInsn|TypeMergeInsn|ListGetInsn;
 public type CallInsn readonly & ["call", FunctionRef, Result, Operand...];
 public type CallGenericInsn readonly & ["call-generic", FunctionRef, Signature, Result, Operand...];
-public type TypeBranchInsn readonly & ["type-branch", Operand, ts:Type, Label, Label, RegisterName, RegisterName];
+public type TypeCondBranchInsn readonly & ["type-cond-branch", Operand, ts:Type, Label, Label, RegisterName, RegisterName];
 public type TypeCastInsn readonly & ["type-cast", Result, ts:Type, Operand];
 public type TypeTestInsn readonly & ["type-test", Result, ts:Type, Operand, boolean];
 public type CondBranchInsn readonly & ["cond-branch", Result, Label, Label];

--- a/compiler/modules/bir.sexpr/serialize.bal
+++ b/compiler/modules/bir.sexpr/serialize.bal
@@ -111,10 +111,10 @@ function formInsn(FuncSerializeContext sc, bir:Insn insn, bir:File file) returns
     else if insn is bir:BranchInsn {
         return [insn.backward ? "branch-back" : "branch", formLabel(sc, insn.dest)];
     }
-    else if insn is bir:TypeBranchInsn {
-        return ["type-branch", fromOperand(sc, insn.operand), fromType(sc, insn.semType),
-                               formLabel(sc, insn.ifTrue), formLabel(sc, insn.ifFalse),
-                               fromRegister(sc, insn.ifTrueRegister), fromRegister(sc, insn.ifFalseRegister)];
+    else if insn is bir:TypeCondBranchInsn {
+        return ["type-cond-branch", fromOperand(sc, insn.operand), fromType(sc, insn.semType),
+                                    formLabel(sc, insn.ifTrue), formLabel(sc, insn.ifFalse),
+                                    fromRegister(sc, insn.ifTrueRegister), fromRegister(sc, insn.ifFalseRegister)];
     }
     else if insn is bir:CondBranchInsn {
         return ["cond-branch", fromRegister(sc, insn.operand), formLabel(sc, insn.ifTrue), formLabel(sc, insn.ifFalse)];

--- a/compiler/modules/bir/bir.bal
+++ b/compiler/modules/bir/bir.bal
@@ -313,7 +313,7 @@ public enum InsnName {
     INSN_TYPE_TEST,
     INSN_BRANCH,
     INSN_COND_BRANCH,
-    INSN_TYPE_BRANCH,
+    INSN_TYPE_COND_BRANCH,
     INSN_TYPE_MERGE,
     INSN_CATCH,
     INSN_PANIC
@@ -345,7 +345,7 @@ public type Insn
     |MappingConstructInsn|MappingGetInsn|MappingSetInsn
     |StringConcatInsn|RetInsn|AbnormalRetInsn|CallInsn|CallIndirectInsn
     |AssignInsn|TypeCastInsn|TypeTestInsn|TypeMergeInsn
-    |BranchInsn|TypeBranchInsn|CondBranchInsn|CatchInsn|PanicInsn|ErrorConstructInsn;
+    |BranchInsn|TypeCondBranchInsn|CondBranchInsn|CatchInsn|PanicInsn|ErrorConstructInsn;
 
 public type Operand ConstOperand|Register;
 
@@ -659,9 +659,9 @@ public type TypeTestInsn readonly & record {|
     boolean negated;
 |};
 
-public type TypeBranchInsn readonly & record {|
+public type TypeCondBranchInsn readonly & record {|
     *InsnBase;
-    INSN_TYPE_BRANCH name = INSN_TYPE_BRANCH;
+    INSN_TYPE_COND_BRANCH name = INSN_TYPE_COND_BRANCH;
     Register operand;
     t:SemType semType;
     Label ifTrue;

--- a/compiler/modules/bir/verify.bal
+++ b/compiler/modules/bir/verify.bal
@@ -133,7 +133,7 @@ function verifyGraph(VerifyCodeContext cx, Label current, Position? predPos = ()
     if term is BranchInsn {
         check verifyChildGraph(cx, term.dest, termPos, term.backward);
     }
-    else if term is TypeBranchInsn|CondBranchInsn {
+    else if term is TypeCondBranchInsn|CondBranchInsn {
         check verifyChildGraph(cx, term.ifTrue, termPos);
         check verifyChildGraph(cx, term.ifFalse, termPos);
     }
@@ -240,7 +240,7 @@ function verifyRegFlow(VerifyCodeContext cx, Label current, RegFlow viaFlow, Pos
         check verifyRegFlow(cx, term.ifTrue, { origin: current, regs: regs.clone() }, termPos);
         check verifyRegFlow(cx, term.ifFalse, { origin: current, regs }, termPos);
     }
-    else if term is TypeBranchInsn {
+    else if term is TypeCondBranchInsn {
         RegSet trueRegs = regs.clone();
         RegSet falseRegs = regs;
         trueRegs[term.ifTrueRegister.number] = true;
@@ -404,8 +404,8 @@ function verifyInsn(VerifyContext vc, Insn insn) returns Error? {
     else if insn is TypeMergeInsn {
         check verifyTypeMerge(vc, insn);
     }
-    else if insn is TypeBranchInsn {
-        check verifyTypeBranch(vc, insn);
+    else if insn is TypeCondBranchInsn {
+        check verifyTypeCondBranch(vc, insn);
     }
 }
 
@@ -429,7 +429,7 @@ function verifyTypeMerge(VerifyContext vc, TypeMergeInsn insn) returns err:Inter
     }
 }
 
-function verifyTypeBranch(VerifyContext vc, TypeBranchInsn insn) returns err:Internal? {
+function verifyTypeCondBranch(VerifyContext vc, TypeCondBranchInsn insn) returns err:Internal? {
     Register unnarrowedOp = unnarrow(insn.operand);
     if unnarrowedOp.number != unnarrow(insn.ifFalseRegister).number || unnarrowedOp.number != unnarrow(insn.ifTrueRegister).number {
         return vc.invalidErr("underlying register of NarrowRegister is incorrect", insn.pos);

--- a/compiler/modules/front/expr.bal
+++ b/compiler/modules/front/expr.bal
@@ -526,7 +526,7 @@ function codeGenNilLift(ExprContext cx, t:SemType? expected, s:Expr[] operands, 
             newOperands[i] = ifFalseRegister;
             bir:BasicBlock ifTrueBlock = maybeCreateBasicBlock(cx, ifNilBlock);
             ifNilBlock = ifTrueBlock;
-            bir:TypeBranchInsn branchInsn = {
+            bir:TypeCondBranchInsn branchInsn = {
                 operand,
                 semType: t:NIL,
                 ifTrue: ifTrueBlock.label,
@@ -1298,7 +1298,7 @@ function codeGenTypeTestForCond(ExprContext cx, bir:BasicBlock nextBlock, t:SemT
     bir:NarrowRegister ifFalseRegister = cx.createNarrowRegister(diff, reg);
     TypeMerger trueMerger = createNarrowMerger(cx, opBinding, ifTrueRegister, pos, nextBlock.label, prevs?.trueMerger);
     TypeMerger falseMerger = createNarrowMerger(cx, opBinding, ifFalseRegister, pos, nextBlock.label, prevs?.falseMerger);
-    bir:TypeBranchInsn insn = { operand: reg, semType: intersect, ifTrue: trueMerger.dest.label, ifFalse: falseMerger.dest.label, ifTrueRegister, ifFalseRegister, pos };
+    bir:TypeCondBranchInsn insn = { operand: reg, semType: intersect, ifTrue: trueMerger.dest.label, ifFalse: falseMerger.dest.label, ifTrueRegister, ifFalseRegister, pos };
     nextBlock.insns.push(insn);
     return { trueMerger, falseMerger };
 }

--- a/compiler/modules/front/stmt.bal
+++ b/compiler/modules/front/stmt.bal
@@ -607,7 +607,7 @@ function codeGenMatchStmt(StmtContext cx, bir:BasicBlock startBlock, BindingChai
             bir:NarrowRegister ifFalseRegister = cx.createNarrowRegister(clauseUnmatchedLooksLike[i], binding.reg, pos);
             bir:BasicBlock nextBlock;
             nextBlock = cx.createBasicBlock("gard." + i.toString());
-            bir:TypeBranchInsn typeBranch = {
+            bir:TypeCondBranchInsn branch = {
                 ifTrue: clauseBlocks[i].label,
                 ifFalse: nextBlock.label,
                 ifTrueRegister,
@@ -618,7 +618,7 @@ function codeGenMatchStmt(StmtContext cx, bir:BasicBlock startBlock, BindingChai
             };
             unmatchedReg = ifFalseRegister;
             clauseBindings[i] = narrow(initialBindings, binding, ifTrueRegister, pos);
-            testBlock.insns.push(typeBranch);
+            testBlock.insns.push(branch);
             testBlock = nextBlock;
         }
     }
@@ -1105,7 +1105,7 @@ function codeGenCheckingCond(ExprContext cx, bir:BasicBlock bb, bir:Register ope
     bir:Register reg = <bir:Register>operand;
     bir:NarrowRegister errorReg = cx.createNarrowRegister(errorType, reg);
     bir:NarrowRegister result = cx.createNarrowRegister(okType, reg);
-    bir:TypeBranchInsn insn = {
+    bir:TypeCondBranchInsn insn = {
         operand: operand,
         semType: t:ERROR,
         ifTrue: errorBlock.label,

--- a/compiler/modules/nback/basic.bal
+++ b/compiler/modules/nback/basic.bal
@@ -120,8 +120,8 @@ function buildBasicBlock(llvm:Builder builder, Scaffold scaffold, bir:BasicBlock
         else if insn is bir:CondBranchInsn {
             check buildCondBranch(builder, scaffold, insn);
         }
-        else if insn is bir:TypeBranchInsn {
-            check buildTypeBranch(builder, scaffold, insn);
+        else if insn is bir:TypeCondBranchInsn {
+            check buildTypeCondBranch(builder, scaffold, insn);
         }
         else if insn is bir:AbnormalRetInsn {
             buildAbnormalRet(builder, scaffold, insn);

--- a/compiler/modules/nback/module.bal
+++ b/compiler/modules/nback/module.bal
@@ -94,7 +94,7 @@ function orderByFwdTargets(bir:BasicBlock[] blocks, bir:Label label, boolean[] v
         if insn is bir:BranchInsn && !insn.backward{
             orderByFwdTargets(blocks, insn.dest, visited, ordered);
         }
-        else if insn is bir:TypeBranchInsn|bir:CondBranchInsn {
+        else if insn is bir:TypeCondBranchInsn|bir:CondBranchInsn {
             orderByFwdTargets(blocks, insn.ifTrue, visited, ordered);
             orderByFwdTargets(blocks, insn.ifFalse, visited, ordered);
         }

--- a/compiler/modules/nback/typeTest.bal
+++ b/compiler/modules/nback/typeTest.bal
@@ -114,7 +114,7 @@ function buildTypeTestedValue(llvm:Builder builder, Scaffold scaffold, bir:Regis
     return { hasType, valueToExactify, value, repr };
 }
 
-function buildTypeBranch(llvm:Builder builder, Scaffold scaffold, bir:TypeBranchInsn insn) returns BuildError? {
+function buildTypeCondBranch(llvm:Builder builder, Scaffold scaffold, bir:TypeCondBranchInsn insn) returns BuildError? {
     TypeTestedValue { hasType } = check buildTypeTestedValue(builder, scaffold, insn.operand, insn.pos, insn.semType);
     llvm:BasicBlock ifTrue = scaffold.basicBlock(insn.ifTrue);
     llvm:BasicBlock ifFalse = scaffold.basicBlock(insn.ifFalse);


### PR DESCRIPTION
Rename type branch to type cond branch to be more consistent with the type branch instruction.
Suggested during March 20th meeting while reviewing #1180.