### PR TITLE
Update to LLVM 16

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
       - name: Cache brew for LLVM (macOS)

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -28,16 +28,16 @@ jobs:
       - name: Install LLVM (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install llvm@15
-          echo "/usr/local/opt/llvm@15/bin" >> $GITHUB_PATH
+          brew install llvm@16
+          echo "/usr/local/opt/llvm@16/bin" >> $GITHUB_PATH
           echo "LLVM_SUFFIX=" >> $GITHUB_ENV
       - name: Install LLVM (linux)
         if: runner.os == 'Linux'
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main
+          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
           sudo apt-get update
-          sudo apt-get install -y clang-15 llvm-15
+          sudo apt-get install -y clang-16 llvm-16
       - name: Cache jBallerina
         id: cache-jbal
         uses: actions/cache@v2

--- a/.github/workflows/validate-jballerina-nightly.yml
+++ b/.github/workflows/validate-jballerina-nightly.yml
@@ -18,6 +18,12 @@ jobs:
           echo 'LATEST_RUN_ID<<EOF' >> $GITHUB_ENV
           gh run list --workflow main.yml  --repo ballerina-platform/ballerina-distribution | grep success | head -n 1 | awk '{print $(NF-2)}' >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
+      - name: Install LLVM 16
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
+          sudo apt-get update
+          sudo apt-get install -y clang-16 llvm-16
       - name: Download jBallerina
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BAL?=bal
-LLVM_SUFFIX?=-15
+LLVM_SUFFIX?=-16
 CLANG?=clang$(LLVM_SUFFIX)
 CFLAGS=-O2
 JAVA?=$(shell test/findJava.sh)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The compiler has not yet got to a stage where it is useful. But if you want to p
 2. [Download](https://ballerina.io/downloads/) and [install](https://ballerina.io/learn/user-guide/getting-started/installation-options/) the latest Ballerina distribution (Swan Lake not 1.2.x)
 3. You can build the compiler by using the command `bal build` in the `compiler` directory; this will generate a file `target/bin/nballerina.jar`. This should work on any system that Ballerina works on.
 4. You can use `java -jar nballerina.jar example.bal` to compile a Ballerina module into an LLVM assembly file `example.ll` (note that only a tiny subset of the language is currently implemented, as described in the Status section).
-5. If you want to be able to turn the LLVM assembly file into something you can execute, there are additional requirements: Linux or OS X, LLVM 15 and GNU make. With these, you can build the runtime and run the tests by running `make test` in the top-level directory. This compiles and executes all the test cases and checks that they produce the right outputs. You can use e.g. `make -j8` to make it run tests in parallel.
+5. If you want to be able to turn the LLVM assembly file into something you can execute, there are additional requirements: Linux or OS X, LLVM 16 and GNU make. With these, you can build the runtime and run the tests by running `make test` in the top-level directory. This compiles and executes all the test cases and checks that they produce the right outputs. You can use e.g. `make -j8` to make it run tests in parallel.
 
 If you want to turn the LLVM assembly into an executable, you can use the [test/run.sh](test/run.sh) command.
 

--- a/llvm_jni/Ballerina.toml
+++ b/llvm_jni/Ballerina.toml
@@ -9,40 +9,40 @@ observabilityIncluded = false
 path = "target/platform-libs/javacpp-platform-1.5.9-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/llvm-platform-15.0.7-1.5.9-SNAPSHOT.jar"
+path = "target/platform-libs/llvm-platform-16.0.1-1.5.9-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/javacpp-1.5.9-20230222.151859-137-linux-x86_64.jar"
+path = "target/platform-libs/javacpp-1.5.9-SNAPSHOT-linux-x86_64.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/javacpp-1.5.9-20230222.151859-137-linux-arm64.jar"
+path = "target/platform-libs/javacpp-1.5.9-SNAPSHOT-linux-arm64.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/javacpp-1.5.9-20230222.151859-137-macosx-arm64.jar"
+path = "target/platform-libs/javacpp-1.5.9-SNAPSHOT-macosx-arm64.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/javacpp-1.5.9-20230222.151859-137-macosx-x86_64.jar"
+path = "target/platform-libs/javacpp-1.5.9-SNAPSHOT-macosx-x86_64.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/javacpp-1.5.9-20230222.151859-137-windows-x86_64.jar"
+path = "target/platform-libs/javacpp-1.5.9-SNAPSHOT-windows-x86_64.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/javacpp-1.5.9-20230222.151859-137.jar"
+path = "target/platform-libs/javacpp-1.5.9-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/llvm-15.0.7-1.5.9-SNAPSHOT-linux-arm64.jar"
+path = "target/platform-libs/llvm-16.0.1-1.5.9-SNAPSHOT-linux-arm64.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/llvm-15.0.7-1.5.9-SNAPSHOT-linux-x86_64.jar"
+path = "target/platform-libs/llvm-16.0.1-1.5.9-SNAPSHOT-linux-x86_64.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/llvm-15.0.7-1.5.9-SNAPSHOT-macosx-x86_64.jar"
+path = "target/platform-libs/llvm-16.0.1-1.5.9-SNAPSHOT-macosx-x86_64.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/llvm-15.0.7-1.5.9-SNAPSHOT-macosx-arm64.jar"
+path = "target/platform-libs/llvm-16.0.1-1.5.9-SNAPSHOT-macosx-arm64.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/llvm-15.0.7-1.5.9-SNAPSHOT-windows-x86_64.jar"
+path = "target/platform-libs/llvm-16.0.1-1.5.9-SNAPSHOT-windows-x86_64.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/llvm-15.0.7-1.5.9-SNAPSHOT.jar"
+path = "target/platform-libs/llvm-16.0.1-1.5.9-SNAPSHOT.jar"

--- a/llvm_jni/BallerinaLinuxX86_64.toml
+++ b/llvm_jni/BallerinaLinuxX86_64.toml
@@ -6,19 +6,19 @@ version = "0.1.0"
 observabilityIncluded = false
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/javacpp-1.5.9-20230222.151859-137.jar"
+path = "target/platform-libs/javacpp-1.5.9-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 path = "target/platform-libs/javacpp-platform-1.5.9-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/javacpp-1.5.9-20230222.151859-137-linux-x86_64.jar"
+path = "target/platform-libs/javacpp-1.5.9-SNAPSHOT-linux-x86_64.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/llvm-15.0.7-1.5.9-SNAPSHOT.jar"
+path = "target/platform-libs/llvm-16.0.1-1.5.9-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/llvm-platform-15.0.7-1.5.9-SNAPSHOT.jar"
+path = "target/platform-libs/llvm-platform-16.0.1-1.5.9-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "target/platform-libs/llvm-15.0.7-1.5.9-SNAPSHOT-linux-x86_64.jar"
+path = "target/platform-libs/llvm-16.0.1-1.5.9-SNAPSHOT-linux-x86_64.jar"

--- a/llvm_jni/build.gradle
+++ b/llvm_jni/build.gradle
@@ -16,8 +16,7 @@ repositories {
 
 dependencies {
         // This is a workaround for missing javacpp in the latest snapshot build
-        implementation 'org.bytedeco:javacpp:1.5.9-20230222.151859-137'
-        implementation 'org.bytedeco:llvm-platform:15.0.7-1.5.9-SNAPSHOT'
+        implementation 'org.bytedeco:llvm-platform:16.0.1-1.5.9-SNAPSHOT'
 }
 
 ext {

--- a/llvm_jni/modules/jni.llvm/Module.bal
+++ b/llvm_jni/modules/jni.llvm/Module.bal
@@ -186,7 +186,6 @@ public distinct class Module {
         jLLVMAddInstructionCombiningPass(modulePassesManager);
         jLLVMAddCFGSimplificationPass(modulePassesManager);
 
-        jLLVMAddPruneEHPass(modulePassesManager);
         jLLVMAddLowerConstantIntrinsicsPass(modulePassesManager);
         
         jLLVMAddStripDeadPrototypesPass(modulePassesManager);
@@ -582,12 +581,6 @@ function jLLVMAddDeadArgEliminationPass(handle passManagerRef) = @java:Method {
 
 function jLLVMAddInstructionCombiningPass(handle passManagerRef) = @java:Method {
     name: "LLVMAddInstructionCombiningPass",
-    'class: "org.bytedeco.llvm.global.LLVM",
-    paramTypes: ["org.bytedeco.llvm.LLVM.LLVMPassManagerRef"]
-} external;
-
-function jLLVMAddPruneEHPass(handle passManagerRef) = @java:Method {
-    name: "LLVMAddPruneEHPass",
     'class: "org.bytedeco.llvm.global.LLVM",
     paramTypes: ["org.bytedeco.llvm.LLVM.LLVMPassManagerRef"]
 } external;

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -51,7 +51,7 @@ $(BT_OBJS): %.o: %.c
 	$(CLANG) -DHAVE_CONFIG_H -funwind-tables -frandom-seed=$< $(BT_WARN_FLAGS) $(CFLAGS) -c -o $@ $<
 
 $(DTOA_OBJS) $(DN_OBJS): %.o: %.c
-	$(CLANG) $(DEFINES) $(CFLAGS) -c -o $@ $<
+	$(CLANG) $(DEFINES) -O1 -c -o $@ $<
 
 %.o: %.bc
 	$(CLANG) -O2 -c -o $@ $<

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -51,7 +51,7 @@ $(BT_OBJS): %.o: %.c
 	$(CLANG) -DHAVE_CONFIG_H -funwind-tables -frandom-seed=$< $(BT_WARN_FLAGS) $(CFLAGS) -c -o $@ $<
 
 $(DTOA_OBJS) $(DN_OBJS): %.o: %.c
-	$(CLANG) $(DEFINES) -O1 -c -o $@ $<
+	$(CLANG) $(DEFINES) $(CFLAGS) -c -o $@ $<
 
 %.o: %.bc
 	$(CLANG) -O2 -c -o $@ $<

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -1,4 +1,4 @@
-LLVM_SUFFIX?=-15
+LLVM_SUFFIX?=-16
 export CLANG ?= clang$(LLVM_SUFFIX)
 LLVM_AS ?= llvm-as$(LLVM_SUFFIX)
 OPT ?= opt$(LLVM_SUFFIX)

--- a/runtime/third-party/decNumber/decCommon.c
+++ b/runtime/third-party/decNumber/decCommon.c
@@ -414,6 +414,7 @@ static decFloat * decFinalize(decFloat *df, bcdnum *num,
     // decShowNum(num, "rounded");
 
     // if exponent is >=emax may have to clamp, overflow, or fold-down
+    uByte buffer[ROUNDUP(DECPMAX+3, 4)]; // [+3 allows uInt padding]
     if (num->exponent>DECEMAX-(DECPMAX-1)) { // is edge case
       // printf("overflow checks...\n");
       if (*ulsd==0 && ulsd==umsd) {     // have zero
@@ -456,7 +457,6 @@ static decFloat * decFinalize(decFloat *df, bcdnum *num,
           // fold down needed; must copy to buffer in order to pad
           // with zeros safely; fortunately this is not the worst case
           // path because cannot have had a round
-          uByte buffer[ROUNDUP(DECPMAX+3, 4)]; // [+3 allows uInt padding]
           uByte *s=umsd;                // source
           uByte *t=buffer;              // safe target
           uByte *tlsd=buffer+(ulsd-umsd)+shift; // target LSD

--- a/runtime/third-party/decNumber/decCommon.c
+++ b/runtime/third-party/decNumber/decCommon.c
@@ -258,6 +258,7 @@ static decFloat * decFinalize(decFloat *df, bcdnum *num,
   // coefficient < DECPMAX
   length=(uInt)(ulsd-umsd+1);                // coefficient length
 
+  uByte buffer[ROUNDUP(DECPMAX+3, 4)]; // [+3 allows uInt padding]
   if (!NUMISSPECIAL(num)) {
     Int   drop;                              // digits to be dropped
     // skip leading insignificant zeros to calculate an exact length
@@ -414,7 +415,6 @@ static decFloat * decFinalize(decFloat *df, bcdnum *num,
     // decShowNum(num, "rounded");
 
     // if exponent is >=emax may have to clamp, overflow, or fold-down
-    uByte buffer[ROUNDUP(DECPMAX+3, 4)]; // [+3 allows uInt padding]
     if (num->exponent>DECEMAX-(DECPMAX-1)) { // is edge case
       // printf("overflow checks...\n");
       if (*ulsd==0 && ulsd==umsd) {     // have zero

--- a/test/balt-sub.mk
+++ b/test/balt-sub.mk
@@ -1,7 +1,7 @@
 COMPILER_JAR=../../../build/compiler/bin/nballerina.jar
 JAVA ?= $(shell ../../../test/findJava.sh)
 TARGETS=all test testll compile
-LLVM_SUFFIX ?=-15
+LLVM_SUFFIX ?=-16
 CLANG ?= clang$(LLVM_SUFFIX)
 LLVM_LINK ?= llvm-link$(LLVM_SUFFIX)
 CFLAGS ?= -O2

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
-LLVM_LINK="llvm-link${LLVM_SUFFIX--15}"
-CLANG="clang${LLVM_SUFFIX--15}"
+LLVM_LINK="llvm-link${LLVM_SUFFIX--16}"
+CLANG="clang${LLVM_SUFFIX--16}"
 b=`basename $1 .ll`
 $LLVM_LINK $1 ../runtime/balrt_inline.bc -o $b.bc
 $LLVM_LINK $b._init.ll ../runtime/balrt_inline.bc -o $b._init.bc

--- a/test/sub.mk
+++ b/test/sub.mk
@@ -29,7 +29,7 @@ else
 endif
 bal_files = $(wildcard ../../../compiler/testSuite/$(tdir)/*-[vpo].bal)
 # These are usd in phase 3
-LLVM_SUFFIX ?=-15
+LLVM_SUFFIX ?=-16
 CLANG ?= clang$(LLVM_SUFFIX)
 LLVM_LINK ?= llvm-link$(LLVM_SUFFIX)
 CFLAGS ?= -O2


### PR DESCRIPTION
## Purpose
Update the llvm version to 16, since the `bytedeco-llvm-preset` (used for `jni-llvm`) has moved to llvm 16