### PR TITLE
Add seed value to all property based test internal errors

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -3,6 +3,7 @@ COMPILER_JAR=../build/compiler/bin/nballerina.jar
 COMPILER_PACK=../build/pack/bala/wso2-nballerina-any-0.1.0.bala
 BAL?=bal
 BAL_BUILD_FLAGS ?= --offline
+PRIVATE_TEST_CONFIGS=./modules/types.regex/tests/Config.toml ./tests/Config.toml
 
 # This disables long running test for the `make test` command, use `bal test` from the compiler directory to run all tests
 BAL_TEST_FLAGS ?= $(BAL_BUILD_FLAGS) --disable-groups longRunning
@@ -14,6 +15,10 @@ pack: $(COMPILER_PACK)
 test:
 	$(BAL) test $(BAL_TEST_FLAGS)
 
+testall: $(PRIVATE_TEST_CONFIGS)
+	$(BAL) test $(BAL_BUILD_FLAGS)
+	-rm $(PRIVATE_TEST_CONFIGS)
+
 $(COMPILER_JAR): $(COMPILER_SRC)
 	$(BAL) build --target-dir ../build/compiler $(BAL_BUILD_FLAGS)
 
@@ -21,9 +26,13 @@ $(COMPILER_PACK): $(COMPILER_SRC)
 	$(BAL) pack --target-dir ../build/pack $(BAL_BUILD_FLAGS)
 	$(BAL) push $(COMPILER_PACK) --repository=local
 
+%/Config.toml:
+	echo 'enablePrivateTests = true' > $*/Config.toml
+
 clean:
 	$(BAL) clean
 	-rm -rf ../build
+	-rm -f $(PRIVATE_TEST_CONFIGS)
 
 .PHONY: all pack test clean
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -3,7 +3,6 @@ COMPILER_JAR=../build/compiler/bin/nballerina.jar
 COMPILER_PACK=../build/pack/bala/wso2-nballerina-any-0.1.0.bala
 BAL?=bal
 BAL_BUILD_FLAGS ?= --offline
-PRIVATE_TEST_CONFIGS=./modules/types.regex/tests/Config.toml ./tests/Config.toml
 
 # This disables long running test for the `make test` command, use `bal test` from the compiler directory to run all tests
 BAL_TEST_FLAGS ?= $(BAL_BUILD_FLAGS) --disable-groups longRunning
@@ -15,10 +14,6 @@ pack: $(COMPILER_PACK)
 test:
 	$(BAL) test $(BAL_TEST_FLAGS)
 
-testall: $(PRIVATE_TEST_CONFIGS)
-	$(BAL) test $(BAL_BUILD_FLAGS)
-	-rm $(PRIVATE_TEST_CONFIGS)
-
 $(COMPILER_JAR): $(COMPILER_SRC)
 	$(BAL) build --target-dir ../build/compiler $(BAL_BUILD_FLAGS)
 
@@ -26,13 +21,9 @@ $(COMPILER_PACK): $(COMPILER_SRC)
 	$(BAL) pack --target-dir ../build/pack $(BAL_BUILD_FLAGS)
 	$(BAL) push $(COMPILER_PACK) --repository=local
 
-%/Config.toml:
-	echo 'enablePrivateTests = true' > $*/Config.toml
-
 clean:
 	$(BAL) clean
 	-rm -rf ../build
-	-rm -f $(PRIVATE_TEST_CONFIGS)
 
 .PHONY: all pack test clean
 

--- a/compiler/modules/types.regex/tests/regextest.bal
+++ b/compiler/modules/types.regex/tests/regextest.bal
@@ -38,9 +38,11 @@ const int MIN_CHUNK_LEN = 1;
 const int SEQUENCE_LEN = 5; // Increasing this value will give much deeply nested regular expressions
 const int SEED = 0;
 
+configurable boolean enablePrivateTests = false;
 @test:Config{
     dataProvider: randomRegexTests,
-    groups: ["longRunning", "random"]
+    groups: ["longRunning", "private"],
+    enable: enablePrivateTests
 }
 function testRandomRegexGeneration(f:SubtypeTestOp op, string lhs, string rhs) {
     test:assertEquals(typeRelation(lhs, rhs), op);

--- a/compiler/modules/types.regex/tests/regextest.bal
+++ b/compiler/modules/types.regex/tests/regextest.bal
@@ -38,11 +38,9 @@ const int MIN_CHUNK_LEN = 1;
 const int SEQUENCE_LEN = 5; // Increasing this value will give much deeply nested regular expressions
 const int SEED = 0;
 
-configurable boolean enablePrivateTests = false;
 @test:Config{
     dataProvider: randomRegexTests,
-    groups: ["longRunning", "private"],
-    enable: enablePrivateTests
+    groups: ["longRunning", "private"]
 }
 function testRandomRegexGeneration(f:SubtypeTestOp op, string lhs, string rhs) {
     test:assertEquals(typeRelation(lhs, rhs), op);

--- a/compiler/modules/types.regex/tests/regextest.bal
+++ b/compiler/modules/types.regex/tests/regextest.bal
@@ -40,7 +40,7 @@ const int SEED = 0;
 
 @test:Config{
     dataProvider: randomRegexTests,
-    groups: ["longRunning"]
+    groups: ["longRunning", "random"]
 }
 function testRandomRegexGeneration(f:SubtypeTestOp op, string lhs, string rhs) {
     test:assertEquals(typeRelation(lhs, rhs), op);

--- a/compiler/tests/propositionGenerator.bal
+++ b/compiler/tests/propositionGenerator.bal
@@ -535,7 +535,7 @@ function evalProposition(PropositionGenContext cx, Proposition p) returns boolea
                 && t:isEmpty(cx.typeContext, t:diff(right, left)) == p.isEmpty;
         }
         _ => {
-            panic error("Invalid OP: " + p.op.toString() + " for seed: " + cx.seed.toString());
+            panic error("invalid OP: " + p.op.toString() + " for seed: " + cx.seed.toString());
         }
     }
     if result == false {

--- a/compiler/tests/testSemtypePropositions.bal
+++ b/compiler/tests/testSemtypePropositions.bal
@@ -1,11 +1,18 @@
 import ballerina/test;
 
-@test:Config { groups: ["longRunning", "random"] }
+configurable boolean enablePrivateTests = false;
+@test:Config {
+    groups: ["longRunning", "private"],
+    enable: enablePrivateTests
+}
 function testSubtyping() {
     testSemtypePropositions(generator = generateSubtypeProposition);
 }
 
-@test:Config { groups: ["longRunning", "random"] }
+@test:Config {
+    groups: ["longRunning", "random"],
+    enable: enablePrivateTests
+}
 function testNonEmptyTypes() {
     testSemtypePropositions(generator = generateNonEmptyProposition);
 }

--- a/compiler/tests/testSemtypePropositions.bal
+++ b/compiler/tests/testSemtypePropositions.bal
@@ -1,11 +1,11 @@
 import ballerina/test;
 
-@test:Config { groups: ["longRunning"] }
+@test:Config { groups: ["longRunning", "random"] }
 function testSubtyping() {
     testSemtypePropositions(generator = generateSubtypeProposition);
 }
 
-@test:Config { groups: ["longRunning"] }
+@test:Config { groups: ["longRunning", "random"] }
 function testNonEmptyTypes() {
     testSemtypePropositions(generator = generateNonEmptyProposition);
 }

--- a/compiler/tests/testSemtypePropositions.bal
+++ b/compiler/tests/testSemtypePropositions.bal
@@ -1,18 +1,11 @@
 import ballerina/test;
 
-configurable boolean enablePrivateTests = false;
-@test:Config {
-    groups: ["longRunning", "private"],
-    enable: enablePrivateTests
-}
+@test:Config { groups: ["longRunning", "private"] }
 function testSubtyping() {
     testSemtypePropositions(generator = generateSubtypeProposition);
 }
 
-@test:Config {
-    groups: ["longRunning", "random"],
-    enable: enablePrivateTests
-}
+@test:Config { groups: ["longRunning", "private"] }
 function testNonEmptyTypes() {
     testSemtypePropositions(generator = generateNonEmptyProposition);
 }

--- a/compiler/tests/typeBuilder.bal
+++ b/compiler/tests/typeBuilder.bal
@@ -4,7 +4,7 @@ import wso2/nballerina.front as f;
 
 type TypeBuilderError error;
 type TypeBuilder object {
-    function semtype(int index) returns t:SemType;
+    function semtype(int index) returns t:SemType|TypeBuilderError;
 
     function typeToString(int index) returns string|TypeBuilderError;
 
@@ -24,7 +24,7 @@ type TypeBuilder object {
 
     function stringConst(string value) returns int;
 
-    function intWidthSigned(int bits) returns int;
+    function intWidthSigned(int bits) returns int|TypeBuilderError;
 
     function xmlType() returns int;
 
@@ -316,12 +316,12 @@ class AstBasedTypeDefBuilder {
         return self.defns[index];
     }
 
-    function semtype(int index) returns t:SemType {
+    function semtype(int index) returns t:SemType|TypeBuilderError {
         t:SemType? t = self.defns[index].semType;
         if t == () {
             error? ret = f:resolveModuleDefFromPart(self.cx, self.modulePart, self.getName(index));
             if ret != () {
-                panic error("Error resolving types", ret);
+                return error("Error resolving types", ret);
             }
             return self.semtype(index);
         }
@@ -366,14 +366,14 @@ class AstBasedTypeDefBuilder {
         return <int>self.intIndex;
     }
 
-    function intWidthSigned(int bits) returns int {
+    function intWidthSigned(int bits) returns int|TypeBuilderError {
         match bits {
             8 | 16 => {
                 string name = "Signed" + bits.toString();
                 return self.createTypeDef(self.createQualifiedTypeDescRef(name, prefix = "int"));
             }
         }
-        panic error("Unsupported int subtype: " + bits.toString());
+        return error("Unsupported int subtype: " + bits.toString());
     }
 
     function xmlSequenceType(int constituentType) returns int {

--- a/compiler/tests/typeBuilder.bal
+++ b/compiler/tests/typeBuilder.bal
@@ -321,7 +321,7 @@ class AstBasedTypeDefBuilder {
         if t == () {
             error? ret = f:resolveModuleDefFromPart(self.cx, self.modulePart, self.getName(index));
             if ret != () {
-                return error("Error resolving types", ret);
+                return error("error resolving types", ret);
             }
             return self.semtype(index);
         }
@@ -373,7 +373,7 @@ class AstBasedTypeDefBuilder {
                 return self.createTypeDef(self.createQualifiedTypeDescRef(name, prefix = "int"));
             }
         }
-        return error("Unsupported int subtype: " + bits.toString());
+        return error("unsupported int subtype: " + bits.toString());
     }
 
     function xmlSequenceType(int constituentType) returns int {


### PR DESCRIPTION
## Purpose
- Make sure there is a seed value with all possible errors in the property-based test
- Explicitly mark all private tests as such ~~(this is to disable them from jBallerina test pipeline)~~
- Make `bal test` only run non private tests