### PR TITLE
Refactor bir call instructions

### DIFF
--- a/compiler/modules/bir.sexpr/names.bal
+++ b/compiler/modules/bir.sexpr/names.bal
@@ -23,7 +23,7 @@ final readonly & InsnNameMapping[] INSN_NAMES = [
     // hand picked
     { sexpr:"set"                  , bir:"INSN_ASSIGN",                         op: () },
     { sexpr:"boolean!"             , bir:"INSN_BOOLEAN_NOT",                    op: () },
-    { sexpr:"call-indirect"        , bir:"INSN_CALL_INDIRECT",                  op: () },
+    { sexpr:"call-inexact"         , bir:"INSN_CALL_INEXACT",                   op: () },
     { sexpr:"less-than"            , bir:"INSN_COMPARE",                        op: "<" },
     { sexpr:"less-than-or-equal"   , bir:"INSN_COMPARE",                        op: "<=" },
     { sexpr:"greater-than"         , bir:"INSN_COMPARE",                        op: ">" },

--- a/compiler/modules/bir.sexpr/names.bal
+++ b/compiler/modules/bir.sexpr/names.bal
@@ -23,7 +23,6 @@ final readonly & InsnNameMapping[] INSN_NAMES = [
     // hand picked
     { sexpr:"set"                  , bir:"INSN_ASSIGN",                         op: () },
     { sexpr:"boolean!"             , bir:"INSN_BOOLEAN_NOT",                    op: () },
-    { sexpr:"call-inexact"         , bir:"INSN_CALL_INEXACT",                   op: () },
     { sexpr:"less-than"            , bir:"INSN_COMPARE",                        op: "<" },
     { sexpr:"less-than-or-equal"   , bir:"INSN_COMPARE",                        op: "<=" },
     { sexpr:"greater-than"         , bir:"INSN_COMPARE",                        op: ">" },

--- a/compiler/modules/bir.sexpr/parse.bal
+++ b/compiler/modules/bir.sexpr/parse.bal
@@ -397,7 +397,7 @@ type BirInsnBase readonly & record {|
 |};
 
 function toCallInsn(FuncParseContext pc, FunctionRef|RegisterName symbolSexpr, Operand[] argsSexpr,
-                    boolean restParamIsList, sexpr:Symbol resultSexpr, Signature? sigSexpr = ()) returns bir:CallInsn|bir:CallIndirectInsn {
+                    boolean restParamIsList, sexpr:Symbol resultSexpr, Signature? sigSexpr = ()) returns bir:CallDirectInsn|bir:CallIndirectInsn {
     bir:Symbol|bir:Register symbol = symbolSexpr is FunctionRef ? symbolFromSexpr(symbolSexpr):
                                                                   lookupRegister(pc, symbolSexpr);
     readonly & bir:Operand[] args = from var arg in argsSexpr select toOperand(pc, arg);

--- a/compiler/modules/bir.sexpr/parse.bal
+++ b/compiler/modules/bir.sexpr/parse.bal
@@ -397,11 +397,11 @@ type BirInsnBase readonly & record {|
     bir:Register result?;
 |};
 
-function toCallInsn(FuncParseContext pc, bir:Symbol|bir:Register symbol, Operand[] argsSexpr, boolean restArgIsList, sexpr:Symbol resultSexpr, Signature? sigSexpr = ()) returns bir:CallInsn {
+function toCallInsn(FuncParseContext pc, bir:Symbol|bir:Register symbol, Operand[] argsSexpr, boolean restParamIsList, sexpr:Symbol resultSexpr, Signature? sigSexpr = ()) returns bir:CallInsn {
     readonly & bir:Operand[] args = from var arg in argsSexpr select toOperand(pc, arg);
     var result = toResultRegister(pc, resultSexpr);
     if symbol is bir:Register {
-        return <bir:CallInsn>{ operands: [symbol, ...args], restArgIsList, pos: 0, result };
+        return <bir:CallIndirectInsn>{ operands: [symbol, ...args], restParamIsList, pos: 0, result };
     }
     t:FunctionSignature erasedSignature = lookupSignature(pc, symbol);
 
@@ -414,7 +414,7 @@ function toCallInsn(FuncParseContext pc, bir:Symbol|bir:Register symbol, Operand
     }
     bir:FunctionConstOperand func = { value: { symbol, signature, erasedSignature },
                                       semType: t:functionSemType(pc.tc, signature) };
-    return <bir:CallInsn>{ operands: [func, ...args], restArgIsList, pos: 0, result };
+    return <bir:CallConstInsn>{ operands: [func, ...args], pos: 0, result };
 }
 
 function lookupLabel(FuncParseContext pc, string name) returns bir:Label {

--- a/compiler/modules/bir.sexpr/parse.bal
+++ b/compiler/modules/bir.sexpr/parse.bal
@@ -251,7 +251,8 @@ function toInsn(FuncParseContext pc, Insn insnSexpr, Position? posSexpr) returns
             panic error("unimplemented instruction: " + sexpr:prettyPrint(data));
         }
         ["call", var symbolSexpr, var resultSexpr, ...var argsSexpr] => {
-            bir:Symbol symbol = symbolFromSexpr(<FunctionRef>symbolSexpr);
+            bir:Symbol|bir:Register symbol = symbolSexpr is FunctionRef ? symbolFromSexpr(<FunctionRef>symbolSexpr) : 
+                                                                          lookupRegister(pc, <RegisterName>symbolSexpr);
             return toCallInsn(pc, symbol, checkpanic argsSexpr.cloneWithType(), <sexpr:Symbol>resultSexpr); // JBUG: remove cloneWithType
         }
         ["call-generic", var symbolSexpr, var signature, var resultSexpr, ...var argsSexpr] => {
@@ -358,7 +359,7 @@ function toInsn(FuncParseContext pc, Insn insnSexpr, Position? posSexpr) returns
     BirInsnBase? insn = ();
     if insnSexpr is ResultInsn {
         match insnSexpr {
-            ["call-indirect", var result, var operand] => { // need to special case this since it's only case operands arrays can have a single operand.
+            ["call-inexact", var result, var operand] => { // need to special case this since it's only case operands arrays can have a single operand.
                 insn = { name, op, pos, result: lookupRegister(pc, checkpanic result.ensureType()),
                          operands: [toOperand(pc, operand)] };
             }
@@ -393,9 +394,12 @@ type BirInsnBase readonly & record {|
     bir:Register result?;
 |};
 
-function toCallInsn(FuncParseContext pc, bir:Symbol symbol, Operand[] argsSexpr, sexpr:Symbol resultSexpr, Signature? sigSexpr = ()) returns bir:CallInsn {
+function toCallInsn(FuncParseContext pc, bir:Symbol|bir:Register symbol, Operand[] argsSexpr, sexpr:Symbol resultSexpr, Signature? sigSexpr = ()) returns bir:CallInsn {
     readonly & bir:Operand[] args = from var arg in argsSexpr select toOperand(pc, arg);
     var result = toResultRegister(pc, resultSexpr);
+    if symbol is bir:Register {
+        return <bir:CallInsn>{ func: symbol, args, pos: 0, result };
+    }
     t:FunctionSignature erasedSignature = lookupSignature(pc, symbol);
 
     t:FunctionSignature signature;
@@ -405,7 +409,9 @@ function toCallInsn(FuncParseContext pc, bir:Symbol symbol, Operand[] argsSexpr,
     else {
         signature = erasedSignature;
     }
-    return <bir:CallInsn>{ func: { symbol, signature, erasedSignature }, args, pos: 0, result };
+    bir:FunctionConstOperand func = { value: { symbol, signature, erasedSignature },
+                                      semType: t:functionSemType(pc.tc, signature) };
+    return <bir:CallInsn>{ func, args, pos: 0, result };
 }
 
 function lookupLabel(FuncParseContext pc, string name) returns bir:Label {

--- a/compiler/modules/bir.sexpr/parse.bal
+++ b/compiler/modules/bir.sexpr/parse.bal
@@ -250,15 +250,21 @@ function toInsn(FuncParseContext pc, Insn insnSexpr, Position? posSexpr) returns
         ["unimpl", ...var data] => {
             panic error("unimplemented instruction: " + sexpr:prettyPrint(data));
         }
-        ["call", var symbolSexpr, var resultSexpr, var restArgIsList, ...var argsSexpr] => {
-            bir:Symbol|bir:Register symbol = symbolSexpr is FunctionRef ? symbolFromSexpr(<FunctionRef>symbolSexpr) : 
+        ["call", var symbolSexpr, var resultSexpr, ...var argsSexpr] => {
+            bir:Symbol|bir:Register symbol = symbolSexpr is FunctionRef ? symbolFromSexpr(<FunctionRef>symbolSexpr):
                                                                           lookupRegister(pc, <RegisterName>symbolSexpr);
-            return toCallInsn(pc, symbol, checkpanic argsSexpr.cloneWithType(), <boolean>restArgIsList, 
+            return toCallInsn(pc, symbol, checkpanic argsSexpr.cloneWithType(), false, 
                               <sexpr:Symbol>resultSexpr); // JBUG: remove cloneWithType
         }
-        ["call-generic", var symbolSexpr, var signature, var resultSexpr, var restArgIsList, ...var argsSexpr] => {
+        ["call-rest-list", var symbolSexpr, var resultSexpr, ...var argsSexpr] => {
+            bir:Symbol|bir:Register symbol = symbolSexpr is FunctionRef ? symbolFromSexpr(<FunctionRef>symbolSexpr):
+                                                                          lookupRegister(pc, <RegisterName>symbolSexpr);
+            return toCallInsn(pc, symbol, checkpanic argsSexpr.cloneWithType(), true, 
+                              <sexpr:Symbol>resultSexpr); // JBUG: remove cloneWithType
+        }
+        ["call-generic", var symbolSexpr, var signature, var resultSexpr, ...var argsSexpr] => {
             bir:Symbol symbol = symbolFromSexpr(<FunctionRef>symbolSexpr);
-            return toCallInsn(pc, symbol, checkpanic argsSexpr.cloneWithType(), <boolean>restArgIsList, <sexpr:Symbol>resultSexpr, <Signature>signature); // JBUG: remove cloneWithType
+            return toCallInsn(pc, symbol, checkpanic argsSexpr.cloneWithType(), false, <sexpr:Symbol>resultSexpr, <Signature>signature); // JBUG: remove cloneWithType
         }
         ["cond-branch", var operand, var ifTrue, var ifFalse] => {
             return <bir:CondBranchInsn>{

--- a/compiler/modules/bir.sexpr/schema.bal
+++ b/compiler/modules/bir.sexpr/schema.bal
@@ -37,9 +37,10 @@ public type MapEntry readonly & [sexpr:String, Operand];
 public type TypeMergePred readonly & [Label, Operand];
 
 public type Insn ResultInsn|OperandInsn|Unimpl|
-                 CallInsn|CallGenericInsn|TypeCondBranchInsn|BranchInsn|TypeCastInsn|TypeTestInsn|CondBranchInsn|MappingConstructInsn|ListConstructInsn|TypeMergeInsn|ListGetInsn;
-public type CallInsn readonly & ["call", FunctionRef|RegisterName, Result, boolean, Operand...];
-public type CallGenericInsn readonly & ["call-generic", FunctionRef, Signature, Result, boolean, Operand...];
+                 CallInsn|CallRestListInsn|CallGenericInsn|TypeCondBranchInsn|BranchInsn|TypeCastInsn|TypeTestInsn|CondBranchInsn|MappingConstructInsn|ListConstructInsn|TypeMergeInsn|ListGetInsn;
+public type CallInsn readonly & ["call", FunctionRef|RegisterName, Result, Operand...];
+public type CallRestListInsn readonly & ["call-rest-list", FunctionRef|RegisterName, Result, Operand...];
+public type CallGenericInsn readonly & ["call-generic", FunctionRef, Signature, Result, Operand...];
 public type TypeCondBranchInsn readonly & ["type-cond-branch", Operand, ts:Type, Label, Label, RegisterName, RegisterName];
 public type TypeCastInsn readonly & ["type-cast", Result, ts:Type, Operand];
 public type TypeTestInsn readonly & ["type-test", Result, ts:Type, Operand, boolean];

--- a/compiler/modules/bir.sexpr/schema.bal
+++ b/compiler/modules/bir.sexpr/schema.bal
@@ -38,8 +38,8 @@ public type TypeMergePred readonly & [Label, Operand];
 
 public type Insn ResultInsn|OperandInsn|Unimpl|
                  CallInsn|CallGenericInsn|TypeCondBranchInsn|BranchInsn|TypeCastInsn|TypeTestInsn|CondBranchInsn|MappingConstructInsn|ListConstructInsn|TypeMergeInsn|ListGetInsn;
-public type CallInsn readonly & ["call", FunctionRef|RegisterName, Result, Operand...];
-public type CallGenericInsn readonly & ["call-generic", FunctionRef, Signature, Result, Operand...];
+public type CallInsn readonly & ["call", FunctionRef|RegisterName, Result, boolean, Operand...];
+public type CallGenericInsn readonly & ["call-generic", FunctionRef, Signature, Result, boolean, Operand...];
 public type TypeCondBranchInsn readonly & ["type-cond-branch", Operand, ts:Type, Label, Label, RegisterName, RegisterName];
 public type TypeCastInsn readonly & ["type-cast", Result, ts:Type, Operand];
 public type TypeTestInsn readonly & ["type-test", Result, ts:Type, Operand, boolean];
@@ -50,7 +50,7 @@ public type TypeMergeInsn readonly & ["type-merge", Result, [Label, Operand]...]
 public type BranchInsn readonly & ["branch"|"branch-back", Label];
 
 type ResultInsn EqualityInsn|AssignInsn|IntBinaryInsn|IntNoPanicArithmeticBinaryInsn|DecimalArithmeticBinaryInsn|ConvertToIntInsn|ListGetInsn|BooleanNotInsn|CatchInsn|CompareInsn|MappingGetInsn|
-                StringConcatInsn|FloatArithmeticBinaryInsn|ConvertToFloatInsn|MappingFillingGetInsn|ConvertToDecimalInsn|FloatNegateInsn|ErrorConstructInsn|DecimalNegateInsn|CallInexactInsn;
+                StringConcatInsn|FloatArithmeticBinaryInsn|ConvertToFloatInsn|MappingFillingGetInsn|ConvertToDecimalInsn|FloatNegateInsn|ErrorConstructInsn|DecimalNegateInsn;
 public type EqualityInsn readonly & ["equal"|"not-equal"|"exact-equal"|"not-exact-equal", Result, Operand, Operand];
 public type AssignInsn readonly & ["set", Result, Operand];
 public type IntBinaryInsn readonly & ["int+"|"int/"|"int-"|"int*"|"int%"|"int^"|"int&"|"int|"|"int<<"|"int>>"|"int>>>", Result, Operand, Operand];
@@ -70,7 +70,6 @@ public type MappingGetInsn readonly & ["mapping-get", Result, RegisterName, Oper
 public type MappingFillingGetInsn readonly & ["mapping-filling-get", Result, RegisterName, Operand];
 public type ErrorConstructInsn readonly & ["error-construct", Result, Operand];
 public type ListGetInsn readonly & ["list-get"|"list-filling-get", Result, Operand, Operand];
-public type CallInexactInsn readonly & ["call-inexact", Result, RegisterName, Operand...];
 
 type OperandInsn RetInsn|AbnormalRetInsn|MappingSetInsn|PanicInsn|ListSetInsn;
 public type RetInsn readonly & ["ret", Operand];

--- a/compiler/modules/bir.sexpr/schema.bal
+++ b/compiler/modules/bir.sexpr/schema.bal
@@ -38,7 +38,7 @@ public type TypeMergePred readonly & [Label, Operand];
 
 public type Insn ResultInsn|OperandInsn|Unimpl|
                  CallInsn|CallGenericInsn|TypeCondBranchInsn|BranchInsn|TypeCastInsn|TypeTestInsn|CondBranchInsn|MappingConstructInsn|ListConstructInsn|TypeMergeInsn|ListGetInsn;
-public type CallInsn readonly & ["call", FunctionRef, Result, Operand...];
+public type CallInsn readonly & ["call", FunctionRef|RegisterName, Result, Operand...];
 public type CallGenericInsn readonly & ["call-generic", FunctionRef, Signature, Result, Operand...];
 public type TypeCondBranchInsn readonly & ["type-cond-branch", Operand, ts:Type, Label, Label, RegisterName, RegisterName];
 public type TypeCastInsn readonly & ["type-cast", Result, ts:Type, Operand];
@@ -50,7 +50,7 @@ public type TypeMergeInsn readonly & ["type-merge", Result, [Label, Operand]...]
 public type BranchInsn readonly & ["branch"|"branch-back", Label];
 
 type ResultInsn EqualityInsn|AssignInsn|IntBinaryInsn|IntNoPanicArithmeticBinaryInsn|DecimalArithmeticBinaryInsn|ConvertToIntInsn|ListGetInsn|BooleanNotInsn|CatchInsn|CompareInsn|MappingGetInsn|
-                StringConcatInsn|FloatArithmeticBinaryInsn|ConvertToFloatInsn|MappingFillingGetInsn|ConvertToDecimalInsn|FloatNegateInsn|ErrorConstructInsn|DecimalNegateInsn|CallIndirectInsn;
+                StringConcatInsn|FloatArithmeticBinaryInsn|ConvertToFloatInsn|MappingFillingGetInsn|ConvertToDecimalInsn|FloatNegateInsn|ErrorConstructInsn|DecimalNegateInsn|CallInexactInsn;
 public type EqualityInsn readonly & ["equal"|"not-equal"|"exact-equal"|"not-exact-equal", Result, Operand, Operand];
 public type AssignInsn readonly & ["set", Result, Operand];
 public type IntBinaryInsn readonly & ["int+"|"int/"|"int-"|"int*"|"int%"|"int^"|"int&"|"int|"|"int<<"|"int>>"|"int>>>", Result, Operand, Operand];
@@ -70,7 +70,7 @@ public type MappingGetInsn readonly & ["mapping-get", Result, RegisterName, Oper
 public type MappingFillingGetInsn readonly & ["mapping-filling-get", Result, RegisterName, Operand];
 public type ErrorConstructInsn readonly & ["error-construct", Result, Operand];
 public type ListGetInsn readonly & ["list-get"|"list-filling-get", Result, Operand, Operand];
-public type CallIndirectInsn readonly & ["call-indirect", Result, RegisterName, Operand...];
+public type CallInexactInsn readonly & ["call-inexact", Result, RegisterName, Operand...];
 
 type OperandInsn RetInsn|AbnormalRetInsn|MappingSetInsn|PanicInsn|ListSetInsn;
 public type RetInsn readonly & ["ret", Operand];

--- a/compiler/modules/bir.sexpr/serialize.bal
+++ b/compiler/modules/bir.sexpr/serialize.bal
@@ -97,9 +97,13 @@ function fromBasicBlock(FuncSerializeContext sc, bir:BasicBlock block, bir:File 
 
 function formInsn(FuncSerializeContext sc, bir:Insn insn, bir:File file) returns Insn {
     if insn is bir:CallInsn {
-        bir:FunctionRef func =  insn.func;
-        FunctionRef ref = fromFunctionRefAccum(sc, func);
+        bir:FunctionConstOperand|bir:Register operand = insn.func;
         (Operand & readonly)[] args = from var arg in insn.args select fromOperand(sc, arg);
+        if operand is bir:Register {
+            return ["call", fromRegister(sc, operand), fromRegister(sc, insn.result), ...args];
+        }
+        bir:FunctionRef func = operand.value;
+        FunctionRef ref = fromFunctionRefAccum(sc, func);
         if func.erasedSignature != func.signature {
             return ["call-generic", ref, fromSignature(sc, func.signature), fromRegister(sc, insn.result), ...args];
         }

--- a/compiler/modules/bir.sexpr/serialize.bal
+++ b/compiler/modules/bir.sexpr/serialize.bal
@@ -96,14 +96,12 @@ function fromBasicBlock(FuncSerializeContext sc, bir:BasicBlock block, bir:File 
 }
 
 function formInsn(FuncSerializeContext sc, bir:Insn insn, bir:File file) returns Insn {
+    if insn is bir:CallIndirectInsn {
+        (readonly & Operand)[] args = from var arg in insn.operands.slice(1) select fromOperand(sc, arg);
+        return callInsn(insn.restParamIsList, fromRegister(sc, insn.operands[0]), fromRegister(sc, insn.result), args);
+    }
     if insn is bir:CallInsn {
         (readonly & Operand)[] args = from var arg in insn.operands.slice(1) select fromOperand(sc, arg);
-        if insn is bir:CallIndirectInsn {
-            // JBUG: can't do
-            // "call"|"call-rest-list" insn_name = insn.resultArgIsList ? "call-rest-list" : "call";
-            // return [insn_name, fromRegister(sc, funcOperand), fromRegister(sc, insn.result), ...args];
-            return callInsn(insn.restParamIsList, fromRegister(sc, insn.operands[0]), fromRegister(sc, insn.result), args);
-        }
         bir:FunctionRef func = (<bir:FunctionConstOperand>insn.operands[0]).value;
         FunctionRef ref = fromFunctionRefAccum(sc, func);
         if func.erasedSignature != func.signature {

--- a/compiler/modules/bir.sexpr/serialize.bal
+++ b/compiler/modules/bir.sexpr/serialize.bal
@@ -102,7 +102,7 @@ function formInsn(FuncSerializeContext sc, bir:Insn insn, bir:File file) returns
     }
     if insn is bir:CallDirectInsn {
         (readonly & Operand)[] args = from var arg in insn.operands.slice(1) select fromOperand(sc, arg);
-        bir:FunctionRef func = (<bir:FunctionConstOperand>insn.operands[0]).value;
+        bir:FunctionRef func = insn.operands[0].value;
         FunctionRef ref = fromFunctionRefAccum(sc, func);
         if func.erasedSignature != func.signature {
             return ["call-generic", ref, fromSignature(sc, func.signature), 

--- a/compiler/modules/bir.sexpr/serialize.bal
+++ b/compiler/modules/bir.sexpr/serialize.bal
@@ -100,7 +100,7 @@ function formInsn(FuncSerializeContext sc, bir:Insn insn, bir:File file) returns
         (readonly & Operand)[] args = from var arg in insn.operands.slice(1) select fromOperand(sc, arg);
         return callInsn(insn.restParamIsList, fromRegister(sc, insn.operands[0]), fromRegister(sc, insn.result), args);
     }
-    if insn is bir:CallInsn {
+    if insn is bir:CallDirectInsn {
         (readonly & Operand)[] args = from var arg in insn.operands.slice(1) select fromOperand(sc, arg);
         bir:FunctionRef func = (<bir:FunctionConstOperand>insn.operands[0]).value;
         FunctionRef ref = fromFunctionRefAccum(sc, func);

--- a/compiler/modules/bir.sexpr/serialize.bal
+++ b/compiler/modules/bir.sexpr/serialize.bal
@@ -97,21 +97,19 @@ function fromBasicBlock(FuncSerializeContext sc, bir:BasicBlock block, bir:File 
 
 function formInsn(FuncSerializeContext sc, bir:Insn insn, bir:File file) returns Insn {
     if insn is bir:CallInsn {
-        bir:FunctionOperand funcOperand = insn.operands[0];
-        (Operand & readonly)[] args = from var arg in insn.operands.slice(1) select fromOperand(sc, arg);
-        if funcOperand is bir:Register {
+        (readonly & Operand)[] args = from var arg in insn.operands.slice(1) select fromOperand(sc, arg);
+        if insn is bir:CallIndirectInsn {
             // JBUG: can't do
             // "call"|"call-rest-list" insn_name = insn.resultArgIsList ? "call-rest-list" : "call";
             // return [insn_name, fromRegister(sc, funcOperand), fromRegister(sc, insn.result), ...args];
-            return callInsn(insn.restArgIsList, fromRegister(sc, funcOperand), fromRegister(sc, insn.result), args);
+            return callInsn(insn.restParamIsList, fromRegister(sc, insn.operands[0]), fromRegister(sc, insn.result), args);
         }
-        bir:FunctionRef func = funcOperand.value;
+        bir:FunctionRef func = (<bir:FunctionConstOperand>insn.operands[0]).value;
         FunctionRef ref = fromFunctionRefAccum(sc, func);
         if func.erasedSignature != func.signature {
             return ["call-generic", ref, fromSignature(sc, func.signature), 
                     fromRegister(sc, insn.result), ...args];
         }
-        // NOTE: is this always correct
         return callInsn(true, ref, fromRegister(sc, insn.result), args);
     }
     else if insn is bir:BranchInsn {

--- a/compiler/modules/bir/bir.bal
+++ b/compiler/modules/bir/bir.bal
@@ -599,9 +599,12 @@ public type CallInsn readonly & record {|
     # Position in the source that resulted in the instruction
     INSN_CALL name = INSN_CALL;
     [FunctionOperand, Operand...] operands;
-    # This indicates whether var args have been accumulated into a single list.
-    # If so the last operand is expected to be that list. This is possible only
-    # when we are calling a function with atomic type.
+    // TODO: after factoring the insn refactor this comment to say,
+    // 1. Call const always expect this form
+    // 2. Indirect call it is optional therefore must explicitly indicate
+    # If the function type is atomic we represent the parameters as a tuple type.
+    # This indicates whether the arguments corresponding to the rest type of that tuple
+    # is given as a single list value in operands.
     boolean restArgIsList;
 |};
 

--- a/compiler/modules/bir/bir.bal
+++ b/compiler/modules/bir/bir.bal
@@ -296,7 +296,7 @@ public enum InsnName {
     INSN_RET,
     INSN_ABNORMAL_RET,
     INSN_CALL,
-    INSN_CALL_INDIRECT,
+    INSN_CALL_INEXACT,
     INSN_INVOKE,
     INSN_ASSIGN,
     INSN_TYPE_CAST,
@@ -333,7 +333,7 @@ public type Insn
     |BooleanNotInsn|CompareInsn|EqualityInsn
     |ListConstructInsn|ListGetInsn|ListSetInsn
     |MappingConstructInsn|MappingGetInsn|MappingSetInsn
-    |StringConcatInsn|RetInsn|AbnormalRetInsn|CallInsn|CallIndirectInsn
+    |StringConcatInsn|RetInsn|AbnormalRetInsn|CallInsn|CallInexactInsn
     |AssignInsn|TypeCastInsn|TypeTestInsn|TypeMergeInsn
     |BranchInsn|TypeCondBranchInsn|CondBranchInsn|CatchInsn|PanicInsn|ErrorConstructInsn;
 
@@ -592,21 +592,22 @@ public type EqualityInsn readonly & record {|
 # any function call could result in a stack overflow panic.
 # XXX This does not handle functions that don't return
 # (i.e. with return type of never)
+# XXX: This can also panic due to memory allocation for uniform function call
+# which is not handled gracefully
 public type CallInsn readonly & record {|
     *ResultInsnBase;
     # Position in the source that resulted in the instruction
     INSN_CALL name = INSN_CALL;
-    FunctionRef func;
+    FunctionConstOperand|Register func;
+    // When there are rest arguments, last argument in the array is a list containing rest arguments
     Operand[] args;
 |};
 
-# Call a function using a function value.
-# This behaves similar to CallInsn.
-# XXX: In addition this can also panic due to memory allocation for uniform function call
-# which is not handled gracefully
-public type CallIndirectInsn readonly & record {|
+# Call a function value by passing arguments directly from the call site, without conforming to convention
+# in CallInsn. This is always a uniform function call. Otherwise this behave like CallInsn.
+public type CallInexactInsn readonly & record {|
     *ResultInsnBase;
-    INSN_CALL_INDIRECT name = INSN_CALL_INDIRECT;
+    INSN_CALL_INEXACT name = INSN_CALL_INEXACT;
     [Register, Operand...] operands;
 |};
 

--- a/compiler/modules/bir/bir.bal
+++ b/compiler/modules/bir/bir.bal
@@ -296,7 +296,6 @@ public enum InsnName {
     INSN_RET,
     INSN_ABNORMAL_RET,
     INSN_CALL,
-    INSN_CALL_INEXACT,
     INSN_INVOKE,
     INSN_ASSIGN,
     INSN_TYPE_CAST,
@@ -333,7 +332,7 @@ public type Insn
     |BooleanNotInsn|CompareInsn|EqualityInsn
     |ListConstructInsn|ListGetInsn|ListSetInsn
     |MappingConstructInsn|MappingGetInsn|MappingSetInsn
-    |StringConcatInsn|RetInsn|AbnormalRetInsn|CallInsn|CallInexactInsn
+    |StringConcatInsn|RetInsn|AbnormalRetInsn|CallInsn
     |AssignInsn|TypeCastInsn|TypeTestInsn|TypeMergeInsn
     |BranchInsn|TypeCondBranchInsn|CondBranchInsn|CatchInsn|PanicInsn|ErrorConstructInsn;
 
@@ -584,6 +583,7 @@ public type EqualityInsn readonly & record {|
     Operand[2] operands;
 |};
 
+public type FunctionOperand FunctionConstOperand|Register;
 # Call a function.
 # This is a not a terminator.
 # This is a PPI. A panic in the called function
@@ -598,17 +598,11 @@ public type CallInsn readonly & record {|
     *ResultInsnBase;
     # Position in the source that resulted in the instruction
     INSN_CALL name = INSN_CALL;
-    FunctionConstOperand|Register func;
-    // When there are rest arguments, last argument in the array is a list containing rest arguments
-    Operand[] args;
-|};
-
-# Call a function value by passing arguments directly from the call site, without conforming to convention
-# in CallInsn. This is always a uniform function call. Otherwise this behave like CallInsn.
-public type CallInexactInsn readonly & record {|
-    *ResultInsnBase;
-    INSN_CALL_INEXACT name = INSN_CALL_INEXACT;
-    [Register, Operand...] operands;
+    [FunctionOperand, Operand...] operands;
+    # This indicates whether var args have been accumulated into a single list.
+    # If so the last operand is expected to be that list. This is possible only
+    # when we are calling a function with atomic type.
+    boolean restArgIsList;
 |};
 
 # Assign a value to a register.

--- a/compiler/modules/bir/bir.bal
+++ b/compiler/modules/bir/bir.bal
@@ -585,21 +585,21 @@ public type EqualityInsn readonly & record {|
 |};
 
 public type FunctionOperand FunctionConstOperand|Register;
-# Call a function. In most cases we don't need to worry about the specific call
-# instruction we have used and instead treat it as this common type.
-# Call instructions are not terminators.
-# Call instructions are PPI. A panic in the called function
-# goes to the onPanic label in the basic block.
-# Regardless of where the function itself panics,
-# any function call could result in a stack overflow panic.
-# If the function type is atomic we represent the parameters as a tuple type.
-# In the case of CallConstInsn, arguments corresponding to the rest type of that tuple
-# are expected to be given as a single list value. In the case of CallIndirectInsn,
-# fallowing this convention for arguments is optional and must be explicitly
-# specified by the restParamIsList.
-# XXX These do not handle functions that don't return
-# (i.e. with return type of never)
-public type CallInsnBase readonly & record {
+// Call a function. In most cases we don't need to worry about the specific call
+// instruction we have used and instead treat it as this common type.
+// Call instructions are not terminators.
+// Call instructions are PPI. A panic in the called function
+// goes to the onPanic label in the basic block.
+// Regardless of where the function itself panics,
+// any function call could result in a stack overflow panic.
+// If the function type is atomic we represent the parameters as a tuple type.
+// In the case of CallConstInsn, arguments corresponding to the rest type of that tuple
+// are expected to be given as a single list value. In the case of CallIndirectInsn,
+// fallowing this convention for arguments is optional and must be explicitly
+// specified by the restParamIsList.
+// XXX These do not handle functions that don't return
+// (i.e. with return type of never)
+public type CallInsnBase record {
     *ResultInsnBase;
     INSN_CALL|INSN_CALL_INDIRECT name;
     [FunctionOperand, Operand...] operands;
@@ -607,7 +607,7 @@ public type CallInsnBase readonly & record {
 
 # Call a constant function value.
 public type CallInsn readonly & record {|
-    *ResultInsnBase;
+    *CallInsnBase;
     INSN_CALL name = INSN_CALL;
     [FunctionConstOperand, Operand...] operands;
 |};
@@ -616,7 +616,7 @@ public type CallInsn readonly & record {|
 # XXX: This can also panic due to memory allocation for uniform function call
 # which is not handled gracefully
 public type CallIndirectInsn readonly & record {|
-    *ResultInsnBase;
+    *CallInsnBase;
     INSN_CALL_INDIRECT name = INSN_CALL_INDIRECT;
     [Register, Operand...] operands;
     boolean restParamIsList;

--- a/compiler/modules/bir/bir.bal
+++ b/compiler/modules/bir/bir.bal
@@ -295,7 +295,7 @@ public enum InsnName {
     INSN_ERROR_CONSTRUCT,
     INSN_RET,
     INSN_ABNORMAL_RET,
-    INSN_CALL_CONST,
+    INSN_CALL,
     INSN_CALL_INDIRECT,
     INSN_INVOKE,
     INSN_ASSIGN,
@@ -333,7 +333,7 @@ public type Insn
     |BooleanNotInsn|CompareInsn|EqualityInsn
     |ListConstructInsn|ListGetInsn|ListSetInsn
     |MappingConstructInsn|MappingGetInsn|MappingSetInsn
-    |StringConcatInsn|RetInsn|AbnormalRetInsn|CallInsn
+    |StringConcatInsn|RetInsn|AbnormalRetInsn|CallInsn|CallIndirectInsn
     |AssignInsn|TypeCastInsn|TypeTestInsn|TypeMergeInsn
     |BranchInsn|TypeCondBranchInsn|CondBranchInsn|CatchInsn|PanicInsn|ErrorConstructInsn;
 
@@ -599,16 +599,16 @@ public type FunctionOperand FunctionConstOperand|Register;
 # specified by the restParamIsList.
 # XXX These do not handle functions that don't return
 # (i.e. with return type of never)
-public type CallInsn readonly & record {
+public type CallInsnBase readonly & record {
     *ResultInsnBase;
-    INSN_CALL_CONST|INSN_CALL_INDIRECT name;
+    INSN_CALL|INSN_CALL_INDIRECT name;
     [FunctionOperand, Operand...] operands;
 };
 
 # Call a constant function value.
-public type CallConstInsn readonly & record {|
+public type CallInsn readonly & record {|
     *ResultInsnBase;
-    INSN_CALL_CONST name = INSN_CALL_CONST;
+    INSN_CALL name = INSN_CALL;
     [FunctionConstOperand, Operand...] operands;
 |};
 

--- a/compiler/modules/bir/verify.bal
+++ b/compiler/modules/bir/verify.bal
@@ -361,7 +361,7 @@ function verifyInsn(VerifyContext vc, Insn insn) returns Error? {
     else if insn is PanicInsn {
         check validOperandError(vc, name, insn.operand, insn.pos);
     }
-    else if insn is CallInsn {
+    else if insn is CallInsnBase {
         check verifyCall(vc, insn);
     }
     else if insn is TypeCastInsn {
@@ -435,7 +435,7 @@ function verifyTypeCondBranch(VerifyContext vc, TypeCondBranchInsn insn) returns
     }
 }
 
-function verifyCall(VerifyContext vc, CallInsn insn) returns err:Internal? {
+function verifyCall(VerifyContext vc, CallInsnBase insn) returns err:Internal? {
     // XXX verify insn.semType
     FunctionOperand func = insn.operands[0];
     if func is FunctionConstOperand {
@@ -447,7 +447,7 @@ function verifyCall(VerifyContext vc, CallInsn insn) returns err:Internal? {
     return verifyFunctionCallArgs(vc, signature.paramTypes, insn);
 }
 
-function verifyFunctionCallArgs(VerifyContext vc, SemType[] paramTypes, CallInsn insn) returns err:Internal? {
+function verifyFunctionCallArgs(VerifyContext vc, SemType[] paramTypes, CallInsnBase insn) returns err:Internal? {
     Operand[] suppliedArgs = insn.operands.slice(1);
     int nSuppliedArgs = suppliedArgs.length();
     int nExpectedArgs = paramTypes.length();

--- a/compiler/modules/bir/verify.bal
+++ b/compiler/modules/bir/verify.bal
@@ -443,6 +443,7 @@ function verifyCall(VerifyContext vc, CallInsnBase insn) returns err:Internal? {
     }
     t:SemType funcTy = func.semType;
     t:FunctionAtomicType atomic = <t:FunctionAtomicType>t:functionAtomicType(vc.typeContext(), funcTy);
+    // TODO: in the non-atomic case verify restParamIsList is not set
     t:FunctionSignature signature = t:functionSignature(vc.typeContext(), atomic);
     return verifyFunctionCallArgs(vc, signature.paramTypes, insn);
 }

--- a/compiler/modules/front/expr.bal
+++ b/compiler/modules/front/expr.bal
@@ -1479,7 +1479,7 @@ function registerName(bir:Register register) returns string {
 function codeGenCall(ExprContext cx, bir:BasicBlock curBlock, bir:FunctionOperand func, 
                      t:SemType returnType, bir:Operand[] args, boolean restParamIsList, Position pos) returns ExprEffect {
     bir:TmpRegister reg = cx.createTmpRegister(returnType, pos);
-    bir:CallIndirectInsn|bir:CallInsn insn;
+    bir:CallIndirectInsn|bir:CallDirectInsn insn;
     if func is bir:FunctionConstOperand {
         insn = { result: reg, operands: [func, ...args], pos };
     }

--- a/compiler/modules/front/expr.bal
+++ b/compiler/modules/front/expr.bal
@@ -1406,7 +1406,8 @@ function codeGenFunctionCallExpr(ExprContext cx, bir:BasicBlock bb, s:FunctionCa
         args.push(arg);
     }
     s:Expr[] restArgs = from int i in regularArgCount ..< expr.args.length() select expr.args[i];
-    if restParamType != () {
+    boolean restArgIsList = restParamType != ();
+    if restArgIsList {
         Position startPos;
         Position endPos;
         int restArgCount = restArgs.length();
@@ -1425,9 +1426,9 @@ function codeGenFunctionCallExpr(ExprContext cx, bir:BasicBlock bb, s:FunctionCa
         args.push(arg);
     }
     check sufficientArguments(cx, func, expr);
-    bir:FunctionConstOperand|bir:Register funcValue = funcRegister != () ? funcRegister : 
+    bir:FunctionOperand funcValue = funcRegister != () ? funcRegister : 
                                                          { value: func, semType: t:functionSemType(cx.mod.tc, func.erasedSignature) };
-    return codeGenCall(cx, curBlock, funcValue, func.signature.returnType, args, expr.qNamePos);
+    return codeGenCall(cx, curBlock, funcValue, func.signature.returnType, args, restArgIsList, expr.qNamePos);
 }
 
 function genLocalFunctionRef(ExprContext cx, string funcName, Position pos) returns [bir:FunctionRef, bir:Register?]|CodeGenError {
@@ -1457,7 +1458,7 @@ function codeGenMethodCallExpr(ExprContext cx, bir:BasicBlock bb, s:MethodCallEx
     }
     check sufficientArguments(cx, func, expr);
     return codeGenCall(cx, curBlock, { value: func, semType: t:functionSemType(cx.mod.tc, func.erasedSignature) }, 
-                       func.signature.returnType, args, expr.namePos);
+                       func.signature.returnType, args, false, expr.namePos);
 }
 
 function functionRefFromAtom(ExprContext cx, t:FunctionAtomicType atom, string identifier) returns bir:FunctionRef {
@@ -1476,13 +1477,13 @@ function registerName(bir:Register register) returns string {
     return <string>register.name;
 }
 
-function codeGenCall(ExprContext cx, bir:BasicBlock curBlock, bir:FunctionConstOperand|bir:Register func, 
-                     t:SemType returnType, bir:Operand[] args, Position pos) returns ExprEffect {
+function codeGenCall(ExprContext cx, bir:BasicBlock curBlock, bir:FunctionOperand func, 
+                     t:SemType returnType, bir:Operand[] args, boolean restArgIsList, Position pos) returns ExprEffect {
     bir:TmpRegister reg = cx.createTmpRegister(returnType, pos);
     bir:CallInsn call = {
-        func,
         result: reg,
-        args: args.cloneReadOnly(),
+        operands: [func, ...args],
+        restArgIsList,
         pos
     };
     curBlock.insns.push(call);

--- a/compiler/modules/nback/basic.bal
+++ b/compiler/modules/nback/basic.bal
@@ -90,9 +90,6 @@ function buildBasicBlock(llvm:Builder builder, Scaffold scaffold, bir:BasicBlock
         else if insn is bir:CallInsn {
             check buildCall(builder, scaffold, insn);
         }
-        else if insn is bir:CallInexactInsn {
-            check buildCallInexact(builder, scaffold, insn);
-        }
         else if insn is bir:ListConstructInsn {
             check buildListConstruct(builder, scaffold, insn);
         }

--- a/compiler/modules/nback/basic.bal
+++ b/compiler/modules/nback/basic.bal
@@ -90,6 +90,9 @@ function buildBasicBlock(llvm:Builder builder, Scaffold scaffold, bir:BasicBlock
         else if insn is bir:CallInsn {
             check buildCall(builder, scaffold, insn);
         }
+        else if insn is bir:CallIndirectInsn {
+            check buildCallIndirect(builder, scaffold, insn);
+        }
         else if insn is bir:ListConstructInsn {
             check buildListConstruct(builder, scaffold, insn);
         }

--- a/compiler/modules/nback/basic.bal
+++ b/compiler/modules/nback/basic.bal
@@ -87,8 +87,8 @@ function buildBasicBlock(llvm:Builder builder, Scaffold scaffold, bir:BasicBlock
         else if insn is bir:TypeTestInsn {
             check buildTypeTest(builder, scaffold, insn);
         }
-        else if insn is bir:CallInsn {
-            check buildCall(builder, scaffold, insn);
+        else if insn is bir:CallDirectInsn {
+            check buildCallDirect(builder, scaffold, insn);
         }
         else if insn is bir:CallIndirectInsn {
             check buildCallIndirect(builder, scaffold, insn);

--- a/compiler/modules/nback/basic.bal
+++ b/compiler/modules/nback/basic.bal
@@ -90,8 +90,8 @@ function buildBasicBlock(llvm:Builder builder, Scaffold scaffold, bir:BasicBlock
         else if insn is bir:CallInsn {
             check buildCall(builder, scaffold, insn);
         }
-        else if insn is bir:CallIndirectInsn {
-            check buildCallIndirect(builder, scaffold, insn);
+        else if insn is bir:CallInexactInsn {
+            check buildCallInexact(builder, scaffold, insn);
         }
         else if insn is bir:ListConstructInsn {
             check buildListConstruct(builder, scaffold, insn);

--- a/compiler/modules/nback/function.bal
+++ b/compiler/modules/nback/function.bal
@@ -42,7 +42,18 @@ final RuntimeFunction addToRestArgsFunction = {
 };
 
 function buildCall(llvm:Builder builder, Scaffold scaffold, bir:CallInsn insn) returns BuildError? {
-    var { symbol: funcSymbol, erasedSignature, signature } = insn.func;
+    bir:FunctionConstOperand|bir:Register func = insn.func;
+    if func is bir:FunctionConstOperand {
+        return finishDirectCall(builder, scaffold, func.value, insn.args, insn.result);
+    }
+    else {
+        return finishIndirectCall(builder, scaffold, func, insn.args, insn.result);
+    }
+}
+
+function finishDirectCall(llvm:Builder builder, Scaffold scaffold, bir:FunctionRef funcRef, bir:Operand[] args,
+                          bir:Register result) returns BuildError? {
+    var { symbol: funcSymbol, erasedSignature, signature } = funcRef;
     llvm:Function func;
     if funcSymbol is bir:InternalSymbol {
         func = scaffold.getFunctionDefn(funcSymbol.identifier);
@@ -51,16 +62,19 @@ function buildCall(llvm:Builder builder, Scaffold scaffold, bir:CallInsn insn) r
         func = check buildFunctionDecl(scaffold, funcSymbol, erasedSignature);
     }
     check finishBuildCall(builder, scaffold, func, erasedSignature.paramTypes, signature.paramTypes,
-                          insn.args, erasedSignature.returnType, insn.result);
+                          args, erasedSignature.returnType, result);
 }
 
-function buildCallIndirect(llvm:Builder builder, Scaffold scaffold, bir:CallIndirectInsn insn) returns BuildError? {
-    // XXX: Once we properly support function types (return type projection), semType will no longer guaranteed to be a function atom
-    // But in cases where semType is not atomic we don't need a signature since they will always be "inexact"
-    t:FunctionAtomicType atomic = <t:FunctionAtomicType>t:functionAtomicType(scaffold.typeContext(), insn.operands[0].semType);
+function buildCallInexact(llvm:Builder builder, Scaffold scaffold, bir:CallInexactInsn insn) returns BuildError? {
+    panic err:unimplemented("inexact call not implemented", scaffold.location(insn.pos));
+}
+
+function finishIndirectCall(llvm:Builder builder, Scaffold scaffold, bir:Register func, bir:Operand[] args,
+                            bir:Register result) returns BuildError? {
+    t:FunctionAtomicType atomic = <t:FunctionAtomicType>t:functionAtomicType(scaffold.typeContext(), func.semType);
     t:FunctionSignature signature = t:functionSignature(scaffold.typeContext(), atomic);
     llvm:PointerType funcValuePtrTy = llvm:pointerType(functionValueType(signature));
-    llvm:PointerValue untaggedFuncValuePtr = buildUntagPointer(builder, scaffold, scaffold.address(insn.operands[0]));
+    llvm:PointerValue untaggedFuncValuePtr = buildUntagPointer(builder, scaffold, scaffold.address(func));
     llvm:ConstPointerValue funcDescPtr = scaffold.getCalledType(signature);
     llvm:Value isExact = buildRuntimeFunctionCall(builder, scaffold, functionIsExactFunction,
                                                   [funcDescPtr, builder.bitCast(untaggedFuncValuePtr, heapPointerType(llFunctionType))]);
@@ -72,13 +86,14 @@ function buildCallIndirect(llvm:Builder builder, Scaffold scaffold, bir:CallIndi
     llvm:BasicBlock afterCall = scaffold.addBasicBlock();
     builder.condBr(isExact, ifExact, ifNotExact);
     builder.positionAtEnd(ifExact);
-    check finishBuildCallIndirectExact(builder, scaffold, insn, afterCall, funcValuePtr, signature);
+    check finishBuildCallIndirectExact(builder, scaffold, args, result, afterCall, funcValuePtr, signature);
     builder.positionAtEnd(ifNotExact);
-    check finishBuildCallIndirectInexact(builder, scaffold, insn, afterCall, funcValuePtr, signature);
+    check finishBuildCallIndirectInexact(builder, scaffold, args, result, afterCall, funcValuePtr, signature);
+
     builder.positionAtEnd(afterCall);
 }
 
-function finishBuildCallIndirectExact(llvm:Builder builder, Scaffold scaffold, bir:CallIndirectInsn insn,
+function finishBuildCallIndirectExact(llvm:Builder builder, Scaffold scaffold, bir:Operand[] args, bir:Register result,
                                       llvm:BasicBlock afterCall, llvm:PointerValue funcValuePtr,
                                       t:FunctionSignature signature) returns BuildError? {
     var { returnType, paramTypes } = signature;
@@ -86,7 +101,7 @@ function finishBuildCallIndirectExact(llvm:Builder builder, Scaffold scaffold, b
                                                                      constIndex(scaffold, 1)],
                                                       "inbounds");
     llvm:PointerValue func = <llvm:PointerValue>builder.load(funcPtr);
-    check finishBuildCall(builder, scaffold, func, paramTypes, paramTypes, insn.operands.slice(1), returnType, insn.result);
+    check finishBuildCall(builder, scaffold, func, paramTypes, paramTypes, args, returnType, result);
     builder.br(afterCall);
 }
 
@@ -103,21 +118,21 @@ function finishBuildCall(llvm:Builder builder, Scaffold scaffold, llvm:Function|
 // `createUniformFunction` defined in `init.bal` converts the uniform representation to direct representation of function definition,
 // call the function pointer and return the result in uniform representation.
 // Then this function convert that result to direct representation of call site type.
-function finishBuildCallIndirectInexact(llvm:Builder builder, Scaffold scaffold, bir:CallIndirectInsn insn,
+function finishBuildCallIndirectInexact(llvm:Builder builder, Scaffold scaffold, bir:Operand[] args, bir:Register result,
                                         llvm:BasicBlock afterCall, llvm:PointerValue funcValuePtr,
                                         t:FunctionSignature signature) returns BuildError? {
     var { returnType, paramTypes, restParamType } = signature;
     int requiredArgCount = restParamType == () ? paramTypes.length() : paramTypes.length() - 1;
-    llvm:Value[] uniformArgs = from int i in 1 ..< requiredArgCount + 1
+    llvm:Value[] uniformArgs = from int i in 0 ..< requiredArgCount 
                                     select buildClearExact(builder, scaffold,
-                                                           (check buildRepr(builder, scaffold, insn.operands[i], REPR_ANY)),
-                                                           insn.operands[i].semType);
+                                                           (check buildRepr(builder, scaffold, args[i], REPR_ANY)),
+                                                           args[i].semType);
     llvm:Value nArgs;
     llvm:PointerValue? restArgs;
     if restParamType !is () {
         // rest is represented as a temporary array
         llvm:PointerValue restArrayPtr = buildUntagPointer(builder, scaffold,
-                                                           scaffold.address(<bir:TmpRegister>insn.operands[requiredArgCount + 1]));
+                                                           scaffold.address(<bir:TmpRegister>args[requiredArgCount]));
         llvm:PointerValue restArgArray = builder.bitCast(restArrayPtr, heapPointerType(llListType));
         llvm:Value restArgCount = builder.load(builder.getElementPtr(restArgArray,
                                                                      [constIndex(scaffold, 0), constIndex(scaffold, 1)],
@@ -156,7 +171,7 @@ function finishBuildCallIndirectInexact(llvm:Builder builder, Scaffold scaffold,
         panic err:impossible("uniform call must return a tagged pointer");
     }
     builder.store(exactReturnValue(builder, scaffold, semTypeRetRepr(returnType), returnVal),
-                  scaffold.address(insn.result));
+                  scaffold.address(result));
     builder.br(afterCall);
 }
 

--- a/compiler/modules/nback/function.bal
+++ b/compiler/modules/nback/function.bal
@@ -131,7 +131,7 @@ function buildCallExact(llvm:Builder builder, Scaffold scaffold, llvm:Function|l
     buildStoreRet(builder, scaffold, semTypeRetRepr(returnTy), retValue, result);
 }
 
-// This builds each arugment in the call instruction as a tagged pointer and store them in an array. We call this array the uniform argument array.
+// This builds each argument in the call instruction as a tagged pointer and store them in an array. We call this array the uniform argument array.
 // In cases where there are rest parameters as a single list (see bir:CallIndirectInsn for more details), this will spread
 // that list into individual arguments in the uniform argument array.
 function buildUniformArgArray(llvm:Builder builder, Scaffold scaffold, bir:CallIndirectInsn insn) returns [llvm:Value, llvm:PointerValue]|BuildError {


### PR DESCRIPTION
## Purpose
Refactor bir call instructions such that they adequately represent different representations of arguments
1. Both `CallInsn` and `CallIndirectInsn` will represent arguments similarly
2. In case of `CallIndirectInsn` explicitly state what format is used to represent rest arguments

Required for #1209 