### PR TITLE
Fix compiler warning in SL U8

### DIFF
--- a/compiler/modules/types/core.bal
+++ b/compiler/modules/types/core.bal
@@ -309,7 +309,7 @@ public class Context {
     }
 }
 
-type ProperSubtypeData StringSubtype|DecimalSubtype|FloatSubtype|IntSubtype|BooleanSubtype|XmlSubtype|BddNode;
+public type ProperSubtypeData StringSubtype|DecimalSubtype|FloatSubtype|IntSubtype|BooleanSubtype|XmlSubtype|BddNode;
 // true means everything and false means nothing (as with Bdd)
 type SubtypeData ProperSubtypeData|boolean;
 


### PR DESCRIPTION
We get a warning on [`ComplexSemType`](https://github.com/ballerina-platform/nballerina/blob/eba6100af833071f45d0c81ca2548c5e57148477/compiler/modules/types/core.bal#L352) since it exposes `ProperSubtypeData` which is not public. Also, note each individual type in the union is already public.