### PR TITLE
Remove restrictions on `explicit-anonymous-function-expr` from conformance tests

### DIFF
--- a/conformance/skiplist.txt
+++ b/conformance/skiplist.txt
@@ -5,7 +5,6 @@ computed-name-field
 decimal-max
 defaultable-param
 error-type-parameter
-explicit-anonymous-function-expr
 float:PI
 handle
 HexFloatingPointLiteral


### PR DESCRIPTION
## Purpose
$(subject)
Depends on #1235
