### PR TITLE
Fix verification complaints from llvm

### DIFF
--- a/compiler/modules/nback/build.bal
+++ b/compiler/modules/nback/build.bal
@@ -91,7 +91,7 @@ final RuntimeFunction taggedToIntFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"]]
 };
 
 final RuntimeFunction taggedToFloatFunction = {
@@ -100,7 +100,7 @@ final RuntimeFunction taggedToFloatFunction = {
         returnType: "double",
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"]]
 };
 
 final RuntimeFunction taggedClearExactAnyFunction = {

--- a/compiler/modules/nback/build.bal
+++ b/compiler/modules/nback/build.bal
@@ -91,7 +91,7 @@ final RuntimeFunction taggedToIntFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"]]
+    attrs: [["param", 0, "readonly"]]
 };
 
 final RuntimeFunction taggedToFloatFunction = {
@@ -100,7 +100,7 @@ final RuntimeFunction taggedToFloatFunction = {
         returnType: "double",
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"]]
+    attrs: [["param", 0, "readonly"]]
 };
 
 final RuntimeFunction taggedClearExactAnyFunction = {

--- a/compiler/modules/nback/build.bal
+++ b/compiler/modules/nback/build.bal
@@ -91,7 +91,7 @@ final RuntimeFunction taggedToIntFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction taggedToFloatFunction = {
@@ -100,7 +100,7 @@ final RuntimeFunction taggedToFloatFunction = {
         returnType: "double",
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction taggedClearExactAnyFunction = {

--- a/compiler/modules/nback/compare.bal
+++ b/compiler/modules/nback/compare.bal
@@ -9,7 +9,7 @@ final RuntimeFunction stringCmpFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction decimalCmpFunction = {
@@ -18,7 +18,7 @@ final RuntimeFunction decimalCmpFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction optIntCompareFunction = {
@@ -27,7 +27,7 @@ final RuntimeFunction optIntCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction optFloatCompareFunction = {
@@ -36,7 +36,7 @@ final RuntimeFunction optFloatCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction optStringCompareFunction = {
@@ -45,7 +45,7 @@ final RuntimeFunction optStringCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction optBooleanCompareFunction = {
@@ -54,7 +54,7 @@ final RuntimeFunction optBooleanCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction optDecimalCompareFunction = {
@@ -63,7 +63,7 @@ final RuntimeFunction optDecimalCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction optListCompareFunction = {
@@ -72,7 +72,7 @@ final RuntimeFunction optListCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction arrayIntCompareFunction = {
@@ -81,7 +81,7 @@ final RuntimeFunction arrayIntCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction arrayFloatCompareFunction = {
@@ -90,7 +90,7 @@ final RuntimeFunction arrayFloatCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction arrayStringCompareFunction = {
@@ -99,7 +99,7 @@ final RuntimeFunction arrayStringCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction arrayBooleanCompareFunction = {
@@ -108,7 +108,7 @@ final RuntimeFunction arrayBooleanCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction arrayListCompareFunction = {
@@ -117,7 +117,7 @@ final RuntimeFunction arrayListCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction arrayExactIntCompareFunction = {
@@ -126,7 +126,7 @@ final RuntimeFunction arrayExactIntCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction arrayDecimalCompareFunction = {
@@ -135,7 +135,7 @@ final RuntimeFunction arrayDecimalCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 type TaggedCompareFunction readonly & record {|

--- a/compiler/modules/nback/compare.bal
+++ b/compiler/modules/nback/compare.bal
@@ -9,7 +9,7 @@ final RuntimeFunction stringCmpFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction decimalCmpFunction = {
@@ -18,7 +18,7 @@ final RuntimeFunction decimalCmpFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction optIntCompareFunction = {
@@ -27,7 +27,7 @@ final RuntimeFunction optIntCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction optFloatCompareFunction = {
@@ -36,7 +36,7 @@ final RuntimeFunction optFloatCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction optStringCompareFunction = {
@@ -45,7 +45,7 @@ final RuntimeFunction optStringCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction optBooleanCompareFunction = {
@@ -54,7 +54,7 @@ final RuntimeFunction optBooleanCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction optDecimalCompareFunction = {
@@ -63,7 +63,7 @@ final RuntimeFunction optDecimalCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction optListCompareFunction = {
@@ -72,7 +72,7 @@ final RuntimeFunction optListCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction arrayIntCompareFunction = {
@@ -81,7 +81,7 @@ final RuntimeFunction arrayIntCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction arrayFloatCompareFunction = {
@@ -90,7 +90,7 @@ final RuntimeFunction arrayFloatCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction arrayStringCompareFunction = {
@@ -99,7 +99,7 @@ final RuntimeFunction arrayStringCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction arrayBooleanCompareFunction = {
@@ -108,7 +108,7 @@ final RuntimeFunction arrayBooleanCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction arrayListCompareFunction = {
@@ -117,7 +117,7 @@ final RuntimeFunction arrayListCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction arrayExactIntCompareFunction = {
@@ -126,7 +126,7 @@ final RuntimeFunction arrayExactIntCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction arrayDecimalCompareFunction = {
@@ -135,7 +135,7 @@ final RuntimeFunction arrayDecimalCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 type TaggedCompareFunction readonly & record {|

--- a/compiler/modules/nback/compare.bal
+++ b/compiler/modules/nback/compare.bal
@@ -9,7 +9,7 @@ final RuntimeFunction stringCmpFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction decimalCmpFunction = {
@@ -18,7 +18,7 @@ final RuntimeFunction decimalCmpFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction optIntCompareFunction = {
@@ -27,7 +27,7 @@ final RuntimeFunction optIntCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction optFloatCompareFunction = {
@@ -36,7 +36,7 @@ final RuntimeFunction optFloatCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction optStringCompareFunction = {
@@ -45,7 +45,7 @@ final RuntimeFunction optStringCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction optBooleanCompareFunction = {
@@ -54,7 +54,7 @@ final RuntimeFunction optBooleanCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction optDecimalCompareFunction = {
@@ -63,7 +63,7 @@ final RuntimeFunction optDecimalCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction optListCompareFunction = {
@@ -72,7 +72,7 @@ final RuntimeFunction optListCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction arrayIntCompareFunction = {
@@ -81,7 +81,7 @@ final RuntimeFunction arrayIntCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction arrayFloatCompareFunction = {
@@ -90,7 +90,7 @@ final RuntimeFunction arrayFloatCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction arrayStringCompareFunction = {
@@ -99,7 +99,7 @@ final RuntimeFunction arrayStringCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction arrayBooleanCompareFunction = {
@@ -108,7 +108,7 @@ final RuntimeFunction arrayBooleanCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction arrayListCompareFunction = {
@@ -117,7 +117,7 @@ final RuntimeFunction arrayListCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction arrayExactIntCompareFunction = {
@@ -126,7 +126,7 @@ final RuntimeFunction arrayExactIntCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction arrayDecimalCompareFunction = {
@@ -135,7 +135,7 @@ final RuntimeFunction arrayDecimalCompareFunction = {
         returnType: "i64",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 type TaggedCompareFunction readonly & record {|

--- a/compiler/modules/nback/equal.bal
+++ b/compiler/modules/nback/equal.bal
@@ -8,7 +8,7 @@ final RuntimeFunction floatEqFunction = {
         returnType: "i1",
         paramTypes:  ["double", "double"]
     },
-    attrs: [["return", "zeroext"], "readonly"]
+    attrs: [["return", "zeroext"]]
 };
 
 final RuntimeFunction floatExactEqFunction = {
@@ -17,7 +17,7 @@ final RuntimeFunction floatExactEqFunction = {
         returnType: "i1",
         paramTypes:  ["double", "double"]
     },
-    attrs: [["return", "zeroext"], "readonly"]
+    attrs: [["return", "zeroext"]]
 };
 
 final RuntimeFunction stringEqFunction = {
@@ -26,7 +26,7 @@ final RuntimeFunction stringEqFunction = {
         returnType: "i1",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [["return", "zeroext"], "readonly"]
+    attrs: [["return", "zeroext"]]
 };
 
 final RuntimeFunction eqFunction = {
@@ -35,7 +35,7 @@ final RuntimeFunction eqFunction = {
         returnType: "i1",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [["return", "zeroext"], "readonly"]
+    attrs: [["return", "zeroext"]]
 };
 
 final RuntimeFunction exactEqFunction = {
@@ -44,7 +44,7 @@ final RuntimeFunction exactEqFunction = {
         returnType: "i1",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [["return", "zeroext"], "readonly"]
+    attrs: [["return", "zeroext"]]
 };
 
 final RuntimeFunction decimalExactEqFunction = {
@@ -53,7 +53,7 @@ final RuntimeFunction decimalExactEqFunction = {
         returnType: "i1",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [["return", "zeroext"], "readonly"]
+    attrs: [["return", "zeroext"]]
 };
 
 type CmpEqOp "ne"|"eq";

--- a/compiler/modules/nback/equal.bal
+++ b/compiler/modules/nback/equal.bal
@@ -26,7 +26,7 @@ final RuntimeFunction stringEqFunction = {
         returnType: "i1",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [["return", "zeroext"], [0, "readonly"], [1, "readonly"]]
+    attrs: [["return", "zeroext"], ["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction eqFunction = {
@@ -35,7 +35,7 @@ final RuntimeFunction eqFunction = {
         returnType: "i1",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [["return", "zeroext"], [0, "readonly"], [1, "readonly"]]
+    attrs: [["return", "zeroext"], ["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction exactEqFunction = {
@@ -44,7 +44,7 @@ final RuntimeFunction exactEqFunction = {
         returnType: "i1",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [["return", "zeroext"], [0, "readonly"], [1, "readonly"]]
+    attrs: [["return", "zeroext"], ["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction decimalExactEqFunction = {
@@ -53,7 +53,7 @@ final RuntimeFunction decimalExactEqFunction = {
         returnType: "i1",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [["return", "zeroext"], [0, "readonly"], [1, "readonly"]]
+    attrs: [["return", "zeroext"], ["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 type CmpEqOp "ne"|"eq";

--- a/compiler/modules/nback/equal.bal
+++ b/compiler/modules/nback/equal.bal
@@ -26,7 +26,7 @@ final RuntimeFunction stringEqFunction = {
         returnType: "i1",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [["return", "zeroext"]]
+    attrs: [["return", "zeroext"], [0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction eqFunction = {
@@ -35,7 +35,7 @@ final RuntimeFunction eqFunction = {
         returnType: "i1",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [["return", "zeroext"]]
+    attrs: [["return", "zeroext"], [0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction exactEqFunction = {
@@ -44,7 +44,7 @@ final RuntimeFunction exactEqFunction = {
         returnType: "i1",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [["return", "zeroext"]]
+    attrs: [["return", "zeroext"], [0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction decimalExactEqFunction = {
@@ -53,7 +53,7 @@ final RuntimeFunction decimalExactEqFunction = {
         returnType: "i1",
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [["return", "zeroext"]]
+    attrs: [["return", "zeroext"], [0, "readonly"], [1, "readonly"]]
 };
 
 type CmpEqOp "ne"|"eq";

--- a/compiler/modules/nback/function.bal
+++ b/compiler/modules/nback/function.bal
@@ -227,7 +227,7 @@ function buildCallExactInner(llvm:Builder builder, Scaffold scaffold, llvm:Funct
     llvm:Value? retValue;
     if capturedVals != () {
         argValues = [capturedVals, ...argValues];
-        // clsoures are always function pointers
+        // closure are always function pointers
         llvm:PointerValue closurePtr = builder.bitCast(<llvm:PointerValue>func,
                                                        llvm:pointerType(buildClosureFunctionSignature(signature, ())));
         retValue = buildFunctionCall(builder, scaffold, closurePtr, argValues);

--- a/compiler/modules/nback/function.bal
+++ b/compiler/modules/nback/function.bal
@@ -224,10 +224,17 @@ function buildCallExactInner(llvm:Builder builder, Scaffold scaffold, llvm:Funct
                              bir:Operand[] args, llvm:Value? capturedVals, bir:Register result, t:SemType returnTy) returns BuildError? {
     llvm:Value[] argValues = check buildFunctionCallArgs(builder, scaffold, erasedSignature.paramTypes,
                                                          signature.paramTypes, args);
+    llvm:Value? retValue;
     if capturedVals != () {
         argValues = [capturedVals, ...argValues];
+        // clsoures are always function pointers
+        llvm:PointerValue closurePtr = builder.bitCast(<llvm:PointerValue>func,
+                                                       llvm:pointerType(buildClosureFunctionSignature(signature, ())));
+        retValue = buildFunctionCall(builder, scaffold, closurePtr, argValues);
     }
-    llvm:Value? retValue = buildFunctionCall(builder, scaffold, func, argValues);
+    else {
+        retValue = buildFunctionCall(builder, scaffold, func, argValues);
+    }
     buildStoreRet(builder, scaffold, semTypeRetRepr(returnTy), retValue, result);
 }
 
@@ -291,7 +298,8 @@ function buildCallInexactInner(llvm:Builder builder, Scaffold scaffold, bir:Regi
                                llvm:PointerValue func, llvm:Value? capturedVals,
                                llvm:PointerValue uniformFuncPtr, llvm:PointerValue uniformArgArray, llvm:Value nArgs,
                                t:SemType returnType) returns BuildError? {
-    llvm:Value[] args = capturedVals == () ? [func, uniformArgArray, nArgs, constBoolean(scaffold, false), constNilTaggedPtr(scaffold)]:
+    llvm:Value[] args = capturedVals == () ? [func, uniformArgArray, nArgs, constBoolean(scaffold, false),
+                                              builder.bitCast(constNilTaggedPtr(scaffold), llvm:pointerType(LLVM_TAGGED_PTR))]:
                                              [func, uniformArgArray, nArgs, constBoolean(scaffold, true), capturedVals];
     llvm:Value? returnVal = buildFunctionCall(builder, scaffold, <llvm:PointerValue>builder.load(uniformFuncPtr),
                                               args);

--- a/compiler/modules/nback/function.bal
+++ b/compiler/modules/nback/function.bal
@@ -299,7 +299,7 @@ function buildCallInexactInner(llvm:Builder builder, Scaffold scaffold, bir:Regi
                                llvm:PointerValue uniformFuncPtr, llvm:PointerValue uniformArgArray, llvm:Value nArgs,
                                t:SemType returnType) returns BuildError? {
     llvm:Value[] args = capturedVals == () ? [func, uniformArgArray, nArgs, constBoolean(scaffold, false),
-                                              builder.bitCast(constNilTaggedPtr(scaffold), llvm:pointerType(LLVM_TAGGED_PTR))]:
+                                              builder.addrSpaceCast(constNilTaggedPtr(scaffold), llvm:pointerType(LLVM_TAGGED_PTR))]:
                                              [func, uniformArgArray, nArgs, constBoolean(scaffold, true), capturedVals];
     llvm:Value? returnVal = buildFunctionCall(builder, scaffold, <llvm:PointerValue>builder.load(uniformFuncPtr),
                                               args);

--- a/compiler/modules/nback/module.bal
+++ b/compiler/modules/nback/module.bal
@@ -86,8 +86,9 @@ function isClosureFunction(bir:Module mod, bir:Function func) returns boolean|Bu
     return false;
 }
 
-function buildClosureFunctionSignature(t:FunctionSignature signature, llvm:PointerType llClosurePtrTy) returns llvm:FunctionType {
-    llvm:Type[] & readonly paramTypes = [llClosurePtrTy, ...from var ty in signature.paramTypes select (semTypeRepr(ty)).llvm];
+function buildClosureFunctionSignature(t:FunctionSignature signature, llvm:PointerType? llClosurePtrTy) returns llvm:FunctionType {
+    llvm:Type[] & readonly paramTypes = [llClosurePtrTy ?: llvm:pointerType(LLVM_TAGGED_PTR),
+                                         ...from var ty in signature.paramTypes select (semTypeRepr(ty)).llvm];
     RetRepr repr = semTypeRetRepr(signature.returnType);
     llvm:FunctionType ty = {
         returnType: repr.llvm,

--- a/compiler/modules/nback/number.bal
+++ b/compiler/modules/nback/number.bal
@@ -20,7 +20,7 @@ final RuntimeFunction decimalNegFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"]]
 };
 
 final RuntimeFunction convertToFloatFunction = {
@@ -29,7 +29,7 @@ final RuntimeFunction convertToFloatFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"]]
 };
 
 final RuntimeFunction decimalToIntFunction = {
@@ -38,7 +38,7 @@ final RuntimeFunction decimalToIntFunction = {
         returnType: LLVM_INT_WITH_OVERFLOW,
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"]]
 };
 
 final RuntimeFunction convertToIntFunction = {
@@ -47,7 +47,7 @@ final RuntimeFunction convertToIntFunction = {
         returnType: llvm:structType([LLVM_TAGGED_PTR, "i1"]),
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"]]
 };
 
 final RuntimeFunction decimalFromIntFunction = {
@@ -74,7 +74,7 @@ final RuntimeFunction convertToDecimalFunction = {
         returnType: LLVM_TAGGED_WITH_PANIC_CODE,
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"]]
 };
 
 final readonly & map<RuntimeFunction> decimalArithmeticFuncs = createDecimalArithmeticFuncs();
@@ -86,7 +86,7 @@ function createDecimalArithmeticFuncs() returns readonly & map<RuntimeFunction> 
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     };
     foreach var [op, name] in decimalArithmeticFuncNames.entries() {
-        m[op] = { name: "decimal_" + name, ty, attrs: [] };
+        m[op] = { name: "decimal_" + name, ty, attrs: [[0, "readonly"]] };
     }
     return m.cloneReadOnly();
 }
@@ -97,7 +97,7 @@ final RuntimeFunction decimalToFloatFunction = {
         returnType: "double",
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"]]
 };
 
 function buildArithmeticBinary(llvm:Builder builder, Scaffold scaffold, bir:IntArithmeticBinaryInsn insn) {

--- a/compiler/modules/nback/number.bal
+++ b/compiler/modules/nback/number.bal
@@ -20,7 +20,7 @@ final RuntimeFunction decimalNegFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"]]
+    attrs: [["param", 0, "readonly"]]
 };
 
 final RuntimeFunction convertToFloatFunction = {
@@ -29,7 +29,7 @@ final RuntimeFunction convertToFloatFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"]]
+    attrs: [["param", 0, "readonly"]]
 };
 
 final RuntimeFunction decimalToIntFunction = {
@@ -38,7 +38,7 @@ final RuntimeFunction decimalToIntFunction = {
         returnType: LLVM_INT_WITH_OVERFLOW,
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"]]
+    attrs: [["param", 0, "readonly"]]
 };
 
 final RuntimeFunction convertToIntFunction = {
@@ -47,7 +47,7 @@ final RuntimeFunction convertToIntFunction = {
         returnType: llvm:structType([LLVM_TAGGED_PTR, "i1"]),
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"]]
+    attrs: [["param", 0, "readonly"]]
 };
 
 final RuntimeFunction decimalFromIntFunction = {
@@ -74,7 +74,7 @@ final RuntimeFunction convertToDecimalFunction = {
         returnType: LLVM_TAGGED_WITH_PANIC_CODE,
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"]]
+    attrs: [["param", 0, "readonly"]]
 };
 
 final readonly & map<RuntimeFunction> decimalArithmeticFuncs = createDecimalArithmeticFuncs();
@@ -86,7 +86,7 @@ function createDecimalArithmeticFuncs() returns readonly & map<RuntimeFunction> 
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     };
     foreach var [op, name] in decimalArithmeticFuncNames.entries() {
-        m[op] = { name: "decimal_" + name, ty, attrs: [[0, "readonly"]] };
+        m[op] = { name: "decimal_" + name, ty, attrs: [["param", 0, "readonly"]] };
     }
     return m.cloneReadOnly();
 }
@@ -97,7 +97,7 @@ final RuntimeFunction decimalToFloatFunction = {
         returnType: "double",
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"]]
+    attrs: [["param", 0, "readonly"]]
 };
 
 function buildArithmeticBinary(llvm:Builder builder, Scaffold scaffold, bir:IntArithmeticBinaryInsn insn) {

--- a/compiler/modules/nback/number.bal
+++ b/compiler/modules/nback/number.bal
@@ -20,7 +20,7 @@ final RuntimeFunction decimalNegFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction convertToFloatFunction = {
@@ -29,7 +29,7 @@ final RuntimeFunction convertToFloatFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction decimalToIntFunction = {
@@ -38,7 +38,7 @@ final RuntimeFunction decimalToIntFunction = {
         returnType: LLVM_INT_WITH_OVERFLOW,
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction convertToIntFunction = {
@@ -47,7 +47,7 @@ final RuntimeFunction convertToIntFunction = {
         returnType: llvm:structType([LLVM_TAGGED_PTR, "i1"]),
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction decimalFromIntFunction = {
@@ -56,7 +56,7 @@ final RuntimeFunction decimalFromIntFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_INT]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction decimalFromFloatFunction = {
@@ -65,7 +65,7 @@ final RuntimeFunction decimalFromFloatFunction = {
         returnType: LLVM_TAGGED_WITH_PANIC_CODE,
         paramTypes: [LLVM_FLOAT]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction convertToDecimalFunction = {
@@ -74,7 +74,7 @@ final RuntimeFunction convertToDecimalFunction = {
         returnType: LLVM_TAGGED_WITH_PANIC_CODE,
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final readonly & map<RuntimeFunction> decimalArithmeticFuncs = createDecimalArithmeticFuncs();
@@ -86,7 +86,7 @@ function createDecimalArithmeticFuncs() returns readonly & map<RuntimeFunction> 
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     };
     foreach var [op, name] in decimalArithmeticFuncNames.entries() {
-        m[op] = { name: "decimal_" + name, ty, attrs: ["readonly"] };
+        m[op] = { name: "decimal_" + name, ty, attrs: [] };
     }
     return m.cloneReadOnly();
 }
@@ -97,7 +97,7 @@ final RuntimeFunction decimalToFloatFunction = {
         returnType: "double",
         paramTypes: [LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 function buildArithmeticBinary(llvm:Builder builder, Scaffold scaffold, bir:IntArithmeticBinaryInsn insn) {

--- a/compiler/modules/nback/structure.bal
+++ b/compiler/modules/nback/structure.bal
@@ -63,7 +63,7 @@ final RuntimeFunction mappingGetFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"]]
+    attrs: [["param", 0, "readonly"]]
 };
 
 final RuntimeFunction mappingFillingGetFunction = {
@@ -81,7 +81,7 @@ final RuntimeFunction mappingIndexedGetFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR, LLVM_INT]
     },
-    attrs: [[0, "readonly"]]
+    attrs: [["param", 0, "readonly"]]
 };
 
 final RuntimeFunction mappingInitMemberFunction = {

--- a/compiler/modules/nback/structure.bal
+++ b/compiler/modules/nback/structure.bal
@@ -54,7 +54,7 @@ final RuntimeFunction listFillingGetFunction = {
         returnType: LLVM_TAGGED_WITH_PANIC_CODE,
         paramTypes: [LLVM_TAGGED_PTR, LLVM_INT]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction mappingGetFunction = {
@@ -63,7 +63,7 @@ final RuntimeFunction mappingGetFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction mappingFillingGetFunction = {
@@ -72,7 +72,7 @@ final RuntimeFunction mappingFillingGetFunction = {
         returnType: LLVM_TAGGED_WITH_PANIC_CODE,
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction mappingIndexedGetFunction = {
@@ -81,7 +81,7 @@ final RuntimeFunction mappingIndexedGetFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR, LLVM_INT]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction mappingInitMemberFunction = {

--- a/compiler/modules/nback/structure.bal
+++ b/compiler/modules/nback/structure.bal
@@ -63,7 +63,7 @@ final RuntimeFunction mappingGetFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR, LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"]]
 };
 
 final RuntimeFunction mappingFillingGetFunction = {
@@ -81,7 +81,7 @@ final RuntimeFunction mappingIndexedGetFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR, LLVM_INT]
     },
-    attrs: []
+    attrs: [[0, "readonly"]]
 };
 
 final RuntimeFunction mappingInitMemberFunction = {

--- a/compiler/modules/nback/typeTest.bal
+++ b/compiler/modules/nback/typeTest.bal
@@ -8,7 +8,7 @@ final RuntimeFunction typeContainsFunction = {
         returnType: LLVM_BOOLEAN,
         paramTypes: [llvm:pointerType(llComplexType), LLVM_TAGGED_PTR]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction typeContainsIntFunction = {
@@ -17,7 +17,7 @@ final RuntimeFunction typeContainsIntFunction = {
         returnType: LLVM_BOOLEAN,
         paramTypes: [llvm:pointerType(llComplexType), LLVM_INT]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction typeContainsFloatFunction = {
@@ -26,7 +26,7 @@ final RuntimeFunction typeContainsFloatFunction = {
         returnType: LLVM_BOOLEAN,
         paramTypes: [llvm:pointerType(llComplexType), LLVM_FLOAT]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 final RuntimeFunction structureExactifyFunction = {
@@ -35,7 +35,7 @@ final RuntimeFunction structureExactifyFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR, llvm:pointerType(LLVM_TID)]
     },
-    attrs: ["readonly"]
+    attrs: []
 };
 
 type TypeTestedValue record {|

--- a/compiler/modules/nback/typeTest.bal
+++ b/compiler/modules/nback/typeTest.bal
@@ -8,7 +8,7 @@ final RuntimeFunction typeContainsFunction = {
         returnType: LLVM_BOOLEAN,
         paramTypes: [llvm:pointerType(llComplexType), LLVM_TAGGED_PTR]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 final RuntimeFunction typeContainsIntFunction = {
@@ -17,7 +17,7 @@ final RuntimeFunction typeContainsIntFunction = {
         returnType: LLVM_BOOLEAN,
         paramTypes: [llvm:pointerType(llComplexType), LLVM_INT]
     },
-    attrs: []
+    attrs: [[0, "readonly"]]
 };
 
 final RuntimeFunction typeContainsFloatFunction = {
@@ -26,7 +26,7 @@ final RuntimeFunction typeContainsFloatFunction = {
         returnType: LLVM_BOOLEAN,
         paramTypes: [llvm:pointerType(llComplexType), LLVM_FLOAT]
     },
-    attrs: []
+    attrs: [[0, "readonly"]]
 };
 
 final RuntimeFunction structureExactifyFunction = {
@@ -35,7 +35,7 @@ final RuntimeFunction structureExactifyFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR, llvm:pointerType(LLVM_TID)]
     },
-    attrs: []
+    attrs: [[0, "readonly"], [1, "readonly"]]
 };
 
 type TypeTestedValue record {|

--- a/compiler/modules/nback/typeTest.bal
+++ b/compiler/modules/nback/typeTest.bal
@@ -8,7 +8,7 @@ final RuntimeFunction typeContainsFunction = {
         returnType: LLVM_BOOLEAN,
         paramTypes: [llvm:pointerType(llComplexType), LLVM_TAGGED_PTR]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 final RuntimeFunction typeContainsIntFunction = {
@@ -17,7 +17,7 @@ final RuntimeFunction typeContainsIntFunction = {
         returnType: LLVM_BOOLEAN,
         paramTypes: [llvm:pointerType(llComplexType), LLVM_INT]
     },
-    attrs: [[0, "readonly"]]
+    attrs: [["param", 0, "readonly"]]
 };
 
 final RuntimeFunction typeContainsFloatFunction = {
@@ -26,7 +26,7 @@ final RuntimeFunction typeContainsFloatFunction = {
         returnType: LLVM_BOOLEAN,
         paramTypes: [llvm:pointerType(llComplexType), LLVM_FLOAT]
     },
-    attrs: [[0, "readonly"]]
+    attrs: [["param", 0, "readonly"]]
 };
 
 final RuntimeFunction structureExactifyFunction = {
@@ -35,7 +35,7 @@ final RuntimeFunction structureExactifyFunction = {
         returnType: LLVM_TAGGED_PTR,
         paramTypes: [LLVM_TAGGED_PTR, llvm:pointerType(LLVM_TID)]
     },
-    attrs: [[0, "readonly"], [1, "readonly"]]
+    attrs: [["param", 0, "readonly"], ["param", 1, "readonly"]]
 };
 
 type TypeTestedValue record {|

--- a/compiler/modules/nback/types.bal
+++ b/compiler/modules/nback/types.bal
@@ -24,7 +24,7 @@ final llvm:FunctionType llUniformFunctionType = llvm:functionType(LLVM_TAGGED_PT
                                                                    llUniformArgArrayType,
                                                                    "i64",
                                                                    LLVM_BOOLEAN,
-                                                                   LLVM_TAGGED_PTR]);
+                                                                   llvm:pointerType(LLVM_TAGGED_PTR)]);
 final llvm:StructType llFunctionDescType = llvm:structType([LLVM_TID,
                                                             llvm:pointerType(llUniformFunctionType),
                                                             LLVM_MEMBER_TYPE,

--- a/compiler/modules/print.llvm/common.bal
+++ b/compiler/modules/print.llvm/common.bal
@@ -72,7 +72,7 @@ public type FunctionEnumAttribute "nocallback"|"nofree"|"nosync"|"readnone"|"nor
 public type ParamEnumAttribute "signext"|"zeroext"|"nest"|"readonly";
 public type ReturnEnumAttribute "signext"|"zeroext"|"noalias";
 public type MemoryAttribure "none";
-public type EnumAttribute FunctionEnumAttribute | (readonly & [int, ParamEnumAttribute]) | (readonly & ["return", ReturnEnumAttribute])| (readonly & ["memory", MemoryAttribure]);
+public type EnumAttribute FunctionEnumAttribute | (readonly & ["param", int, ParamEnumAttribute]) | (readonly & ["return", ReturnEnumAttribute])| (readonly & ["memory", MemoryAttribure]);
 
 // Subtype of LLVMOpcode
 

--- a/compiler/modules/print.llvm/common.bal
+++ b/compiler/modules/print.llvm/common.bal
@@ -68,7 +68,7 @@ public function functionType(RetType returnType, Type[] paramTypes) returns Func
 // Corresponds to LLVMLinkage enum
 public type Linkage "internal"|"external";
 
-public type FunctionEnumAttribute "nocallback"|"nofree"|"nosync"|"readnone"|"noreturn"|"cold"|"nounwind"|"readnone"|"readonly"|"speculatable"|"willreturn";
+public type FunctionEnumAttribute "nocallback"|"nofree"|"nosync"|"readnone"|"noreturn"|"cold"|"nounwind"|"readnone"|"speculatable"|"willreturn";
 public type ParamEnumAttribute "signext"|"zeroext"|"nest";
 public type ReturnEnumAttribute "signext"|"zeroext"|"noalias";
 public type MemoryAttribure "none";

--- a/compiler/modules/print.llvm/common.bal
+++ b/compiler/modules/print.llvm/common.bal
@@ -69,7 +69,7 @@ public function functionType(RetType returnType, Type[] paramTypes) returns Func
 public type Linkage "internal"|"external";
 
 public type FunctionEnumAttribute "nocallback"|"nofree"|"nosync"|"readnone"|"noreturn"|"cold"|"nounwind"|"readnone"|"speculatable"|"willreturn";
-public type ParamEnumAttribute "signext"|"zeroext"|"nest";
+public type ParamEnumAttribute "signext"|"zeroext"|"nest"|"readonly";
 public type ReturnEnumAttribute "signext"|"zeroext"|"noalias";
 public type MemoryAttribure "none";
 public type EnumAttribute FunctionEnumAttribute | (readonly & [int, ParamEnumAttribute]) | (readonly & ["return", ReturnEnumAttribute])| (readonly & ["memory", MemoryAttribure]);

--- a/compiler/modules/print.llvm/llvm.bal
+++ b/compiler/modules/print.llvm/llvm.bal
@@ -86,7 +86,7 @@ public class Context {
         return new(self);
     }
 
-    public function constStruct(Value[] elements) returns ConstValue {
+    public function constStruct(Value[] elements, StructType? ty = ()) returns ConstValue {
         string[] structBody = [];
         Type[] elemTypes = [];
         structBody.push("{");

--- a/compiler/modules/print.llvm/llvm.bal
+++ b/compiler/modules/print.llvm/llvm.bal
@@ -787,8 +787,7 @@ function addEnumAttributeInner(EnumAttribute attribute, FunctionBase func) {
         ReturnEnumAttribute attrib = attribute[1];
         func.addReturnAttribute(attrib);
     } else {
-        ParamEnumAttribute attrib = attribute[1];
-        int paramIndex = attribute[0];
+        var [_, paramIndex, attrib] = attribute;
         func.addParamAttribute(paramIndex, attrib);
     }
 }

--- a/compiler/modules/print.llvm/tests/functionAttrib.bal
+++ b/compiler/modules/print.llvm/tests/functionAttrib.bal
@@ -7,7 +7,7 @@ function functionAttrib() returns Module {
     FunctionDefn test = m.addFunctionDefn("test", {returnType: "i64", paramTypes: ["i64", "i64", "i64"]});
     test.addEnumAttribute("nounwind");
     test.addEnumAttribute(["return", "noalias"]);
-    test.addEnumAttribute([0, "zeroext"]);
+    test.addEnumAttribute(["param", 0, "zeroext"]);
     Value p0 = test.getParam(0);
     Value p1 = test.getParam(1);
     Value p2 = test.getParam(2);
@@ -20,7 +20,7 @@ function functionAttrib() returns Module {
     FunctionDecl test2 = m.addFunctionDecl("test2", {returnType:"i64", paramTypes:["i64", "i64", "i64"]});
     test2.addEnumAttribute("nounwind");
     test2.addEnumAttribute(["return", "noalias"]);
-    test2.addEnumAttribute([0, "zeroext"]);
+    test2.addEnumAttribute(["param", 0, "zeroext"]);
     return m;
 }
 

--- a/llvm_jni/modules/jni.llvm/Context.bal
+++ b/llvm_jni/modules/jni.llvm/Context.bal
@@ -40,8 +40,15 @@ public distinct class Context {
         return new (jLLVMConstStringInContext(self.LLVMContext, java:fromString(checkpanic string:fromBytes(bytes)), bytes.length(), 1), arrayType("i8", bytes.length()));
     }
 
-    public function constStruct(Value[] elements) returns ConstValue {
-        return new (jLLVMConstStructInContext(self.LLVMContext, PointerPointerFromValues(elements).jObject, elements.length(), 0), structType(from var element in elements select element.ty));
+    public function constStruct(Value[] elements, StructType? ty = ()) returns ConstValue {
+        if ty != () && ty.name != () {
+            return new(jLLVMConstNamedStruct(typeToLLVMType(self, ty), PointerPointerFromValues(elements).jObject,
+                                             elements.length()),
+                       ty);
+        }
+        return new (jLLVMConstStructInContext(self.LLVMContext, PointerPointerFromValues(elements).jObject,
+                                              elements.length(), 0),
+                    structType(from var element in elements select element.ty));
     }
 
     public function constArray(Type elementType, ConstValue[] values) returns ConstValue {
@@ -129,6 +136,12 @@ function jLLVMConstStructInContext(handle context, handle values, int count, int
     name: "LLVMConstStructInContext",
     'class: "org.bytedeco.llvm.global.LLVM",
     paramTypes: ["org.bytedeco.llvm.LLVM.LLVMContextRef", "org.bytedeco.javacpp.PointerPointer", "int", "int"]
+} external;
+
+function jLLVMConstNamedStruct(handle typeRef, handle values, int count) returns handle = @java:Method {
+    name: "LLVMConstNamedStruct",
+    'class: "org.bytedeco.llvm.global.LLVM",
+    paramTypes: ["org.bytedeco.llvm.LLVM.LLVMTypeRef", "org.bytedeco.javacpp.PointerPointer", "int"]
 } external;
 
 function jLLVMConstGEP(handle ty, handle pointer, handle indices, int numIndices) returns handle = @java:Method {

--- a/llvm_jni/modules/jni.llvm/Function.bal
+++ b/llvm_jni/modules/jni.llvm/Function.bal
@@ -49,31 +49,26 @@ public distinct class Function {
     }
 
     public function addEnumAttribute(EnumAttribute attribute) {
-        handle? attributeName = ();
-        int? index = ();
-        int? attributeNameLength = ();
-        if attribute is FunctionEnumAttribute {
-            index = -1;
-            attributeName = java:fromString(attribute);
-            string attributeContent = attribute;
-            attributeNameLength = attributeContent.length();
-        } else {
-            if attribute[0] == "return" {
+        int index;
+        string attributeContent;
+        match attribute {
+            ["return", var attr] => {
                 index = 0;
-            } else {
-                index = <int>attribute[0] + 1;
+                attributeContent = attr;
             }
-            string attributeContent = attribute[1];
-            attributeNameLength = attributeContent.length();
-            attributeName = java:fromString(attributeContent);
+            ["param", var i, var attr] => {
+                index = i + 1;
+                attributeContent = attr;
+            }
+            var attr => {
+                index = -1;
+                attributeContent = <FunctionEnumAttribute>attr;
+            }
         }
-        if attributeName is () || index is () || attributeNameLength is (){
-            panic error("Failed to convert the given attribute");
-        } else {
-            int attrKind = jLLVMGetEnumAttributeKindForName(attributeName, attributeNameLength);
-            handle attr = jLLVMCreateEnumAttribute(self.context.LLVMContext, attrKind, 0);
-            jLLVMAddAttributeAtIndex(self.LLVMValueRef, index, attr);
-        }
+        handle attributeName = java:fromString(attributeContent);
+        int attrKind = jLLVMGetEnumAttributeKindForName(attributeName, attributeContent.length());
+        handle attr = jLLVMCreateEnumAttribute(self.context.LLVMContext, attrKind, 0);
+        jLLVMAddAttributeAtIndex(self.LLVMValueRef, index, attr);
     }
 
     public function setGC(string? name) {

--- a/llvm_jni/modules/jni.llvm/Type.bal
+++ b/llvm_jni/modules/jni.llvm/Type.bal
@@ -1,20 +1,18 @@
 import ballerina/jballerina.java;
 
+
 function typeToLLVMType(Context context, RetType ty) returns handle {
     if ty is PointerType {
-        handle baseType = typeToLLVMType(context, ty.pointsTo);
-        return jLLVMPointerType(baseType, ty.addressSpace);
+        return jLLVMPointerTypeInContext(context.LLVMContext, ty.addressSpace);
     }
     if ty is StructType {
-        if context is Context {
-            handle? namedTy = context.namedStructTypeToLLVMType(ty);
-            if namedTy is handle {
-                return namedTy;
-            }
+        handle? namedTy = context.namedStructTypeToLLVMType(ty);
+        if namedTy is handle {
+            return namedTy;
         }
         PointerPointer typeArr = PointerPointerFromTypes(context, ty.elementTypes);
         int elementCount = ty.elementTypes.length();
-        return jLLVMStructType(typeArr.jObject, elementCount, 0);
+        return jLLVMStructTypeInContext(context.LLVMContext, typeArr.jObject, elementCount, 0);
     }
     if ty is ArrayType {
         handle elementType = typeToLLVMType(context, ty.elementType);
@@ -158,10 +156,10 @@ function jLLVMConstPointerNull(handle ty) returns handle = @java:Method {
     paramTypes: ["org.bytedeco.llvm.LLVM.LLVMTypeRef"]
 } external;
 
-function jLLVMPointerType(handle ty, int addressSpace) returns handle = @java:Method {
-    name: "LLVMPointerType",
+function jLLVMPointerTypeInContext(handle ty, int addressSpace) returns handle = @java:Method {
+    name: "LLVMPointerTypeInContext",
     'class: "org.bytedeco.llvm.global.LLVM",
-    paramTypes: ["org.bytedeco.llvm.LLVM.LLVMTypeRef", "int"]
+    paramTypes: ["org.bytedeco.llvm.LLVM.LLVMContextRef", "int"]
 } external;
 
 function jLLVMArrayType(handle elementType, int elementCount) returns handle = @java:Method {
@@ -170,8 +168,8 @@ function jLLVMArrayType(handle elementType, int elementCount) returns handle = @
     paramTypes: ["org.bytedeco.llvm.LLVM.LLVMTypeRef", "int"]
 } external;
 
-function jLLVMStructType(handle elementTypes, int elementCount, int packed) returns handle = @java:Method {
-    name: "LLVMStructType",
+function jLLVMStructTypeInContext(handle contextRef, handle elementTypes, int elementCount, int packed) returns handle = @java:Method {
+    name: "LLVMStructTypeInContext",
     'class: "org.bytedeco.llvm.global.LLVM",
-    paramTypes: ["org.bytedeco.javacpp.PointerPointer", "int", "int"]
+    paramTypes: ["org.bytedeco.llvm.LLVM.LLVMContextRef", "org.bytedeco.javacpp.PointerPointer", "int", "int"]
 } external;

--- a/llvm_jni/modules/jni.llvm/tests/functionAttrib.bal
+++ b/llvm_jni/modules/jni.llvm/tests/functionAttrib.bal
@@ -7,7 +7,7 @@ function functionAttrib() returns Module {
     FunctionDefn test = m.addFunctionDefn("test", {returnType: "i64", paramTypes: ["i64", "i64", "i64"]});
     test.addEnumAttribute("nounwind");
     test.addEnumAttribute(["return", "noalias"]);
-    test.addEnumAttribute([0, "zeroext"]);
+    test.addEnumAttribute(["param", 0, "zeroext"]);
     Value p0 = test.getParam(0);
     Value p1 = test.getParam(1);
     Value p2 = test.getParam(2);
@@ -20,7 +20,7 @@ function functionAttrib() returns Module {
     FunctionDecl test2 = m.addFunctionDecl("test2", {returnType:"i64", paramTypes:["i64", "i64", "i64"]});
     test2.addEnumAttribute("nounwind");
     test2.addEnumAttribute(["return", "noalias"]);
-    test2.addEnumAttribute([0, "zeroext"]);
+    test2.addEnumAttribute(["param", 0, "zeroext"]);
     return m;
 }
 


### PR DESCRIPTION
## Purpose
+ Add a module verification stage to jni.llvm to ensure "in memory representation" of the module is valid
  + Fixed raised issues by validator
+ Add a more simplified optimization pipeline using the LLVM's `PassManagerBuilder`
Resolves #1244 